### PR TITLE
Enforce next-server as a peer-dep

### DIFF
--- a/packages/fab-nextjs/package.json
+++ b/packages/fab-nextjs/package.json
@@ -34,6 +34,9 @@
     "ts-node": "^7",
     "typescript": "^3.0"
   },
+  "peerDependency": {
+    "next-server": "*"
+  },
   "engines": {
     "node": ">=8.0.0"
   },


### PR DESCRIPTION
Can't force the version here as it's in lock-step with the version of `next` used, so it has to be a peer dep