### PR TITLE
Restore previous @fab/compile asset returning behaviour

### DIFF
--- a/packages/fab-compile/src/files/fab-entry.js
+++ b/packages/fab-compile/src/files/fab-entry.js
@@ -20,14 +20,7 @@ export async function render(req, settings) {
 
   const rewrite = rewrites[pathname]
   if (rewrite) {
-    //return await fetchAndReturn(`${protocol}//${host}${rewrite}`)
-    return new Response(null, {
-      status: 302,
-      statusText: 'Found',
-      headers: {
-        Location: `${protocol}//${host}${rewrite}`
-      }
-    })
+    return await fetchAndReturn(`${protocol}//${host}${rewrite}`)
   }
   return await render_app(req, settings)
 }


### PR DESCRIPTION
Rollback @fab/compile version to the previous minor release. This changed how files not within the `_assets` directory were handled:

* In both cases, files like `/build/xyz.js` were renamed & moved to `/_assets/_public/build/xyz.a1b2c3d4.js`
* Previously, the FAB _proxied_ these requests, so the URL that the browser sees was still `/build/xyz.js`
* This was changed due to AWS Lambda@Edge limiting responses to 1mb, so the FAB would return a `302 Redirect` to the real asset path (which bypassed the FAB at the CDN level). But that caused issues in some cases (there'll be a config settings/knowledge base article about this in future).

In this case, the old behaviour prevented `@fab/serve` from serving a FAB with redirects inside a Codesandbox.

---

## Codesandbox verification

This is the first PR where we can observe failure behaviour before & fixed behaviour after with two Codesandboxes:

* Before: https://codesandbox.io/s/prod-breeze-ugrui
* After: https://codesandbox.io/s/pensive-wildflower-bnipe

Both of these are running `fab-static build` on a fresh create-react-app project, but using different versions of the `@fab/static` (and underlying `@fab/compile`) package. These packages were generated & published by Codesandbox CI, but since that [doesn't fork docker-based sandboxes](https://twitter.com/glenmaddern/status/1196467165211373570), I had to hack them in manually. Still, the auto-publishing per-commit is _awesome_, and we can verify that this 100% works!

This will only get more streamlined, but it's already awesome that we can do this!