### PR TITLE
Add function check for next-config

### DIFF
--- a/packages/input-nextjs/src/preflightChecks.ts
+++ b/packages/input-nextjs/src/preflightChecks.ts
@@ -19,7 +19,13 @@ export async function preflightChecks(
     `)
   }
 
-  const next_config = require(next_config_path)
+  const next_config_at_path = require(next_config_path)
+
+  const next_config =
+    typeof next_config_at_path === 'function'
+      ? next_config_at_path('', {})
+      : next_config_at_path
+
   if (next_config.target !== 'serverless') {
     throw new BuildFailedError(`Not serverless build
       NextJS project needs to be set to ${chalk.yellow('target: serverless')}


### PR DESCRIPTION
(copied from the other PR)
According to https://nextjs.org/docs/api-reference/next.config.js/introduction next.config.js can export a function that takes a phase and an object and returns a config.

I added a check that will run the function if that is what is returned from the next.config.js