### PR TITLE
Change output format to UMD, so a FAB can be required in a Node env

### DIFF
--- a/packages/cli/src/actions/Compiler.ts
+++ b/packages/cli/src/actions/Compiler.ts
@@ -12,7 +12,7 @@ export class Compiler {
       output: [output, ...chunks],
     } = await rollupCompile(
       require.resolve('@fab/cli/lib/runtime'),
-      { format: 'iife', exports: 'named' },
+      { format: 'umd', exports: 'named', name: '__fab' },
       {
         ...proto_fab.hypotheticals,
         'user-defined-pipeline': generatePipelineJs(render_plugins),

--- a/packages/server/src/sandboxes/node-vm.ts
+++ b/packages/server/src/sandboxes/node-vm.ts
@@ -27,8 +27,8 @@ export default async (src: string): Promise<FabSpecExports> => {
   }
 
   const script = new vm.Script(src)
-  const exp = {}
-  const ctx = Object.assign({}, sandbox, { module: { exports: exp } })
-  const renderer = script.runInNewContext(ctx)
-  return renderer
+  const exp: any = {}
+  const ctx = Object.assign({}, sandbox, { module: { exports: exp }, exports: exp })
+  script.runInNewContext(ctx)
+  return exp
 }


### PR DESCRIPTION
With `iife`, it is not possible to `require` a FAB in a regular Node environment. With an UMD build we have both `iife`, `CommonJS` and a global namespace to work with.