### PR TITLE
Asset proxying

### DIFF
--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -60,17 +60,15 @@ For `create-react-app`:
 
 ```sh
 # in the fab/tests dir
-FAB_E2E_CRA_DIR=/var/folders/83/r8pycjcn0d93h/T/tmp-20093cop/cra-test yarn test create-react-app
+FAB_E2E_SKIP_CREATE=true yarn test create-react-app
 ```
 
 For `nextjs`:
 
 ```sh
 # in the fab/tests dir
-FAB_E2E_NEXTJS_DIR=/var/folders/83/r8pycjcn0d93h/T/tmp-10668Ibj/nextjs-test yarn test nextjs
+FAB_E2E_SKIP_CREATE=true yarn test nextjs
 ```
-
-Note the `/var/folders/.../[cra|nextjs]-test` directory is **whatever your last test run used** (you should see it in the console logs). This format skips the creation of a new project, instead using `git reset --hard` and `git clean -df` to restore the project to its previous state.
 
 ### Tweaking tests & source code
 

--- a/docs/kb/plugin-runtime.mdx
+++ b/docs/kb/plugin-runtime.mdx
@@ -4,6 +4,8 @@ route: '/kb/plugin-runtime-responders'
 menu: Knowledge Base
 ---
 
+# Plugin Runtime Responders
+
 Most of the time, if you're looking into customising the server-side functionality of a FAB, you want to introduce a file with a `runtime` function that sets up a `Responder`. The simple case looks like this:
 
 ```js
@@ -45,7 +47,7 @@ export function runtime(args, metadata) {
   return async function responder(request_context) {
     const { url } = request_context
 
-    if (url.pathname === 'not-my-problem') {
+    if (url.pathname === '/not-my-problem') {
       return undefined
     }
 
@@ -59,15 +61,16 @@ export function runtime(args, metadata) {
     }
 
     if (url.pathname.startsWith('/api')) {
-      return await fetch(`https://example.backend${url.pathname}`)
+      return new Request(`https://example.backend${url.pathname}`)
     }
 
-    if (url.pathname === '/_assets/favicon.ico') {
-      return {
-        directive: 'asset_fetch',
-        immutable: false,
-        path: '/_assets/favicon.a1b2c3d4f3.ico',
-      }
+    if (url.pathname === '/favicon.ico') {
+      const response = await fetch('/_assets/favicon.a1b2c3d4f3.ico')
+      response.headers.set('cache-control', 'no-cache')
+      return response
+      // could do an api on top like
+      // return await FAB.fetchNoCache('/_assets/favicon.a1b2c3d4f3.ico')
+      // but probably not worth it, is it?
     }
   }
 }

--- a/docs/wip/new-assets.md
+++ b/docs/wip/new-assets.md
@@ -1,0 +1,13 @@
+Two return values for FAB responders:
+
+`return new Request(relative_or_abs)`
+
+Means, proxy this pls. If it's relative, it means, serve this asset. If absolute, proxy.
+
+The original requests' headers are then used in the request.
+
+`return fetch(relative_or_abs)`
+
+Fetch will normally explode with a relative url, but we're considering that to be an "asset fetch". Up to the runtime to make it happen.
+
+No headers persisted (the user can merge the original request if they choose)

--- a/packages/cli/src/runtime/index.ts
+++ b/packages/cli/src/runtime/index.ts
@@ -34,6 +34,10 @@ export const render: FabSpecRender = async (request: Request, settings: FabSetti
     const response = await responders({ request, settings, url })
     if (!response) continue
 
+    if (response instanceof Request) {
+      return response
+    }
+
     if (response instanceof Response) {
       let response_in_chain = response
       for (const interceptor of response_interceptors) {
@@ -42,6 +46,9 @@ export const render: FabSpecRender = async (request: Request, settings: FabSetti
       return response_in_chain
     }
 
+    // Really want to throw a meaningful exception if you return something
+    // that isn't a "Directive", but that might be best done as a refactor
+    // of the whole "sync function returns async responder" API...
     const directive = response as Directive
     if (typeof directive.interceptResponse === 'function') {
       // Unshift rather than push, so the reduce runs in the right order above.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,7 +103,10 @@ export enum SandboxType {
  * between the platform-specific runtimes (@fab/server,
  * @fab/cf-workers-wrapper, Linc.sh etc) and the FAB itself.
  * */
-export type FabSpecRender = (request: Request, settings: FabSettings) => Promise<Request | Response>
+export type FabSpecRender = (
+  request: Request,
+  settings: FabSettings
+) => Promise<Request | Response>
 export type FabSpecMetadata = {
   production_settings: FabSettings
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,7 +63,7 @@ export type FabRequestContext = {
 }
 export type FabRequestResponder = (
   context: FabRequestContext
-) => Promise<Response | undefined | Directive>
+) => Promise<undefined | Request | Response | Directive>
 
 export type ResponseInterceptor = (response: Response) => Promise<Response>
 
@@ -103,7 +103,7 @@ export enum SandboxType {
  * between the platform-specific runtimes (@fab/server,
  * @fab/cf-workers-wrapper, Linc.sh etc) and the FAB itself.
  * */
-export type FabSpecRender = (request: Request, settings: FabSettings) => Promise<Response>
+export type FabSpecRender = (request: Request, settings: FabSettings) => Promise<Request | Response>
 export type FabSpecMetadata = {
   production_settings: FabSettings
 }
@@ -112,3 +112,5 @@ export type FabSpecExports = {
   render: FabSpecRender
   metadata: FabSpecMetadata
 }
+
+export type FetchApi = (url: string | Request, init?: RequestInit) => Promise<Response>

--- a/packages/rewire-assets/src/runtime.ts
+++ b/packages/rewire-assets/src/runtime.ts
@@ -27,7 +27,7 @@ export const runtime: FabPluginRuntime<RewireAssetsArgs, RewireAssetsMetadata> =
     const renamed = matchPath(renamed_assets, pathname)
     if (renamed) {
       if (renamed.immutable) {
-        console.log("Returning new request!!")
+        console.log('Returning new request!!')
         return new Request(renamed.asset_path)
       } else {
         const response = await fetch(renamed.asset_path)

--- a/packages/sandbox-node-vm/src/index.ts
+++ b/packages/sandbox-node-vm/src/index.ts
@@ -1,10 +1,10 @@
 import vm from 'vm'
 import * as fetch from 'node-fetch'
-import { FabSpecExports } from '@fab/core'
+import {FabSpecExports, FetchApi} from '@fab/core'
 
-export default async (src: string): Promise<FabSpecExports> => {
+export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports> => {
   const sandbox = {
-    fetch: fetch,
+    fetch: enhanced_fetch,
     Request: fetch.Request,
     Response: fetch.Response,
     Headers: fetch.Headers,

--- a/packages/sandbox-node-vm/src/index.ts
+++ b/packages/sandbox-node-vm/src/index.ts
@@ -1,6 +1,6 @@
 import vm from 'vm'
 import * as fetch from 'node-fetch'
-import {FabSpecExports, FetchApi} from '@fab/core'
+import { FabSpecExports, FetchApi } from '@fab/core'
 
 export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports> => {
   const sandbox = {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "@types/express": "^4.17.2",
     "@types/node": "^12.12.14",
     "@types/yauzl": "^2.9.1",
+    "cross-fetch": "^3.0.4",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",
     "get-stream": "^5.1.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,15 +1,15 @@
 import fs from 'fs-extra'
 
-import {FetchApi, getContentType, SandboxType, ServerArgs} from '@fab/core'
-import {InvalidConfigError, JSON5Config} from '@fab/cli'
-import {readFilesFromZip} from './utils'
+import { FetchApi, getContentType, SandboxType, ServerArgs } from '@fab/core'
+import { InvalidConfigError, JSON5Config } from '@fab/cli'
+import { readFilesFromZip } from './utils'
 import v8_sandbox from './sandboxes/v8-isolate'
 import node_vm_sandbox from '@fab/sandbox-node-vm'
 import url from 'url'
 import http from 'http'
 import express from 'express'
 import concat from 'concat-stream'
-import fetch, {Request as NodeFetchRequest} from 'cross-fetch'
+import fetch, { Request as NodeFetchRequest } from 'cross-fetch'
 
 export default class Server {
   private filename: string
@@ -105,7 +105,7 @@ export default class Server {
               )
             )
             if (fetch_res instanceof NodeFetchRequest) {
-            console.log("GOT ME A NODE BOI REQUEST")
+              console.log('GOT ME A NODE BOI REQUEST')
               console.log(fetch_res)
               console.log(fetch_res.url)
               fetch_res = await enhanced_fetch(fetch_res)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,15 +1,15 @@
 import fs from 'fs-extra'
 
-import { ServerArgs, SandboxType, getContentType } from '@fab/core'
-import { InvalidConfigError, JSON5Config } from '@fab/cli'
-import { readFilesFromZip } from './utils'
+import {FetchApi, getContentType, SandboxType, ServerArgs} from '@fab/core'
+import {InvalidConfigError, JSON5Config} from '@fab/cli'
+import {readFilesFromZip} from './utils'
 import v8_sandbox from './sandboxes/v8-isolate'
 import node_vm_sandbox from '@fab/sandbox-node-vm'
 import url from 'url'
 import http from 'http'
 import express from 'express'
 import concat from 'concat-stream'
-import { Request as NodeFetchRequest } from 'node-fetch'
+import fetch, {Request as NodeFetchRequest} from 'cross-fetch'
 
 export default class Server {
   private filename: string
@@ -46,10 +46,20 @@ export default class Server {
     }
     const src = src_buffer.toString('utf8')
 
+    const enhanced_fetch: FetchApi = async (url, init?) => {
+      const request_url = typeof url === 'string' ? url : url.url
+      if (request_url.startsWith('/')) {
+        // Need a smarter wau to fetch assets, of course, but for now...
+        return fetch(`http://localhost:${this.port}${request_url}`, init)
+      }
+
+      return fetch(url, init)
+    }
+
     const renderer =
       (await runtimeType) === SandboxType.v8isolate
         ? await v8_sandbox(src)
-        : await node_vm_sandbox(src)
+        : await node_vm_sandbox(src, enhanced_fetch)
 
     await new Promise((resolve, reject) => {
       const app = express()
@@ -83,7 +93,7 @@ export default class Server {
 
             const production_settings = renderer.metadata?.production_settings
             // console.log({production_settings})
-            const fetch_res = await renderer.render(
+            let fetch_res = await renderer.render(
               // @ts-ignore
               fetch_req as Request,
               Object.assign(
@@ -94,6 +104,12 @@ export default class Server {
                 settings_overrides
               )
             )
+            if (fetch_res instanceof NodeFetchRequest) {
+            console.log("GOT ME A NODE BOI REQUEST")
+              console.log(fetch_res)
+              console.log(fetch_res.url)
+              fetch_res = await enhanced_fetch(fetch_res)
+            }
             console.log({ status: fetch_res.status })
             res.status(fetch_res.status)
             // This is a NodeFetch response, which has this method, but
@@ -123,7 +139,7 @@ export default class Server {
       server.listen(this.port, resolve)
     })
 
-    console.log(`Listening on port ${this.port}`)
+    console.log(`Listening on http://localhost:${this.port}`)
   }
 
   private async getSettingsOverrides() {

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -114,7 +114,7 @@ describe('Create React App E2E Test', () => {
       const port = getPort()
       await createServer(port)
 
-      await shell('tree build', { cwd })
+      // await shell('tree build', { cwd })
 
       const globs = await globby('static/js/main*.js', { cwd: path.join(cwd, 'build') })
       const main_js = globs[0]

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -88,7 +88,7 @@ describe('Create React App E2E Test', () => {
       return stdout
     }
 
-    it.skip('should return a 200 on / and /hello', async () => {
+    it('should return a 200 on / and /hello', async () => {
       // Test that global builds work too
       if (process.env.PUBLIC_PACKAGES) {
         await buildFab(cwd, true)
@@ -117,7 +117,7 @@ describe('Create React App E2E Test', () => {
       console.log({ main_js })
     })
 
-    it.skip('should allow a plugin to override /hello', async () => {
+    it('should allow a plugin to override /hello', async () => {
       await fs.ensureDir(`${cwd}/fab-plugins`)
       await fs.writeFile(
         `${cwd}/fab-plugins/hello-world.js`,
@@ -155,7 +155,7 @@ describe('Create React App E2E Test', () => {
       expect(hello_response).toContain('HELLO WORLD!')
     })
 
-    it.skip('should reflect settings changes', async () => {
+    it('should reflect settings changes', async () => {
       await buildFab(cwd)
       const first_fab_md5 = await md5file(`${cwd}/fab.zip`)
       console.log({ first_fab_md5 })

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -20,8 +20,12 @@ describe('Create React App E2E Test', () => {
     } else {
       // Create a new CRA project inside
       await shell(`yarn create react-app .`, { cwd })
-      await shell(`git add .`, { cwd })
-      await shell(`git commit -m CREATED`, { cwd })
+      // Skip git stuff on Github, it's only for rerunning locally
+      if (!process.env.GITHUB_WORKSPACE) {
+        await shell(`git init`, { cwd })
+        await shell(`git add .`, { cwd })
+        await shell(`git commit -m CREATED`, { cwd })
+      }
     }
     // Expect that {cwd} has a package.json
     const { stdout: files } = await cmd(`ls -l`, { cwd })
@@ -84,7 +88,7 @@ describe('Create React App E2E Test', () => {
       return stdout
     }
 
-    it('should return a 200 on / and /hello', async () => {
+    it.skip('should return a 200 on / and /hello', async () => {
       // Test that global builds work too
       if (process.env.PUBLIC_PACKAGES) {
         await buildFab(cwd, true)
@@ -109,11 +113,11 @@ describe('Create React App E2E Test', () => {
       const port = getPort()
       await createServer(port)
 
-      const main_js = globby('build/static/js/main*.js', { cwd })
-      console.log([main_js])
+      const main_js = await globby('build/static/js/main*.js', { cwd })
+      console.log({ main_js })
     })
 
-    it('should allow a plugin to override /hello', async () => {
+    it.skip('should allow a plugin to override /hello', async () => {
       await fs.ensureDir(`${cwd}/fab-plugins`)
       await fs.writeFile(
         `${cwd}/fab-plugins/hello-world.js`,
@@ -151,7 +155,7 @@ describe('Create React App E2E Test', () => {
       expect(hello_response).toContain('HELLO WORLD!')
     })
 
-    it('should reflect settings changes', async () => {
+    it.skip('should reflect settings changes', async () => {
       await buildFab(cwd)
       const first_fab_md5 = await md5file(`${cwd}/fab.zip`)
       console.log({ first_fab_md5 })

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -15,11 +15,13 @@ describe('Create React App E2E Test', () => {
     cwd = await getWorkingDir('cra-test', !process.env.FAB_E2E_SKIP_CREATE)
     if (process.env.FAB_E2E_SKIP_CREATE) {
       console.log({ cwd })
-      await shell(`echo git reset --hard`, { cwd })
-      await shell(`echo git clean -df`, { cwd })
+      await shell(`git reset --hard`, { cwd })
+      await shell(`git clean -df`, { cwd })
     } else {
       // Create a new CRA project inside
       await shell(`yarn create react-app .`, { cwd })
+      await shell(`git add .`, { cwd })
+      await shell(`git commit -m 'Post-create state'`, { cwd })
     }
     // Expect that {cwd} has a package.json
     const { stdout: files } = await cmd(`ls -l`, { cwd })
@@ -49,7 +51,7 @@ describe('Create React App E2E Test', () => {
     expect(files_after_fab_build).toMatch('fab.zip')
   })
 
-  describe.skip('fab build tests', () => {
+  describe('fab build tests', () => {
     let server_process: ExecaChildProcess | null = null
 
     const cancelServer = () => {

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -21,7 +21,7 @@ describe('Create React App E2E Test', () => {
       // Create a new CRA project inside
       await shell(`yarn create react-app .`, { cwd })
       await shell(`git add .`, { cwd })
-      await shell(`git commit -m 'Post-create state'`, { cwd })
+      await shell(`git commit -m CREATED`, { cwd })
     }
     // Expect that {cwd} has a package.json
     const { stdout: files } = await cmd(`ls -l`, { cwd })

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -24,6 +24,5 @@ export const getWorkingDir = async (dirname: string, clean: boolean) => {
   }
 
   await fs.ensureDir(cwd)
-  await shell(`git init`, { cwd })
   return cwd
 }

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -1,0 +1,28 @@
+import { cmd, shell } from '../../utils'
+import fs from 'fs-extra'
+import path from 'path'
+
+let next_port = 3310
+export const getPort = () => next_port++
+
+export const buildFab = async (cwd: string, global = false) => {
+  await shell(`rm -f fab.zip`, { cwd })
+  await shell(global ? `fab build` : `yarn fab:build`, { cwd })
+
+  const { stdout: files_after_fab_build } = await cmd(`ls -l ${cwd}`)
+  expect(files_after_fab_build).toMatch('fab.zip')
+}
+
+const workspace_dir = path.resolve(__dirname, '../workspace')
+console.log({ workspace_dir })
+export const getWorkingDir = async (dirname: string, clean: boolean) => {
+  const working_dir = path.join(workspace_dir, dirname)
+  console.log({ working_dir })
+
+  if (clean && (await fs.pathExists(working_dir))) {
+    await fs.remove(working_dir)
+  }
+
+  await fs.ensureDir(working_dir)
+  return working_dir
+}

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -16,14 +16,14 @@ export const buildFab = async (cwd: string, global = false) => {
 const workspace_dir = path.resolve(__dirname, '../workspace')
 console.log({ workspace_dir })
 export const getWorkingDir = async (dirname: string, clean: boolean) => {
-  const working_dir = path.join(workspace_dir, dirname)
-  console.log({ working_dir })
+  const cwd = path.join(workspace_dir, dirname)
+  console.log({ working_dir: cwd })
 
-  if (clean && (await fs.pathExists(working_dir))) {
-    await fs.remove(working_dir)
+  if (clean && (await fs.pathExists(cwd))) {
+    await fs.remove(cwd)
   }
 
-  await fs.ensureDir(working_dir)
-  await shell(`git init`, { working_dir })
-  return working_dir
+  await fs.ensureDir(cwd)
+  await shell(`git init`, { cwd })
+  return cwd
 }

--- a/tests/e2e/helpers/index.ts
+++ b/tests/e2e/helpers/index.ts
@@ -24,5 +24,6 @@ export const getWorkingDir = async (dirname: string, clean: boolean) => {
   }
 
   await fs.ensureDir(working_dir)
+  await shell(`git init`, { working_dir })
   return working_dir
 }

--- a/tests/e2e/nextjs-9.test.ts
+++ b/tests/e2e/nextjs-9.test.ts
@@ -6,7 +6,7 @@ import { ExecaChildProcess } from 'execa'
 let next_port = 3210
 const getPort = () => next_port++
 
-describe('Create React App E2E Test', () => {
+describe.skip('Create React App E2E Test', () => {
   let tmpdir: string
   let cwd: string
 

--- a/tests/e2e/nextjs-9.test.ts
+++ b/tests/e2e/nextjs-9.test.ts
@@ -6,7 +6,7 @@ import { ExecaChildProcess } from 'execa'
 let next_port = 3210
 const getPort = () => next_port++
 
-describe.skip('Create React App E2E Test', () => {
+describe('Create React App E2E Test', () => {
   let tmpdir: string
   let cwd: string
 

--- a/tests/e2e/nextjs-9.test.ts
+++ b/tests/e2e/nextjs-9.test.ts
@@ -1,5 +1,5 @@
-import * as tmp from 'tmp-promise'
-import * as fs from 'fs-extra'
+import tmp from 'tmp-promise'
+import fs from 'fs-extra'
 import { shell, cmd } from '../utils'
 import { ExecaChildProcess } from 'execa'
 

--- a/tests/e2e/paths-exist.test.ts
+++ b/tests/e2e/paths-exist.test.ts
@@ -1,4 +1,4 @@
-import * as execa from 'execa'
+import execa from 'execa'
 
 it('should have our packages installed', async () => {
   if (!process.env.PUBLIC_PACKAGES) {

--- a/tests/e2e/static.test.ts
+++ b/tests/e2e/static.test.ts
@@ -1,4 +1,4 @@
-import * as tmp from 'tmp-promise'
+import tmp from 'tmp-promise'
 import { expectError, shell } from '../utils'
 
 describe('dir of static assets', () => {

--- a/tests/e2e/workspace/.gitignore
+++ b/tests/e2e/workspace/.gitignore
@@ -1,0 +1,2 @@
+/*
+!.gitignore

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,9 +6,8 @@
     "strict": true,
     "target": "es2017",
     "composite": true,
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "esModuleInterop": true
   },
-  "include": [
-    "**/*"
-  ]
+  "include": ["**/*"]
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -6,6 +6,7 @@ export const cmd = (command: string, ...opts: any) => {
 }
 
 export const shell = async (command: string, ...opts: any) => {
+  if (opts.cwd) process.stdout.write(`[${opts.cwd}] `)
   const promise = cmd(command, ...opts)
   promise.stdout!.pipe(process.stdout)
   promise.stderr!.pipe(process.stderr)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,13 +2046,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@0.9.5, bl@~0.8.1:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-0.9.5.tgz#c06b797af085ea00bc527afc8efcf11de2232054"
-  integrity sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=
-  dependencies:
-    readable-stream "~1.0.26"
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -2067,6 +2060,13 @@ bl@^3.0.0:
   integrity sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==
   dependencies:
     readable-stream "^3.0.1"
+
+bl@~0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
+  integrity sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=
+  dependencies:
+    readable-stream "~1.0.26"
 
 bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
@@ -2978,6 +2978,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -6468,7 +6476,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -9307,6 +9315,11 @@ webpack@^4.41.5:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
+
+whatwg-fetch@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Implementing the new Request/Response returning API for `fab serve`.

This is the first big breaking change for the FAB runtime, but since we're still in pre-release for all the FAB stuff this will be just another v0 point release for the moment, until we're sure it doesn't need to be broken again.