### PR TITLE
Gatsby compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/fab/contribute)]
 
-<a href="https://opencollective.com/fab/organization/0/website"><img src="https://opencollective.com/fab/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/1/website"><img src="https://opencollective.com/fab/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/2/website"><img src="https://opencollective.com/fab/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/3/website"><img src="https://opencollective.com/fab/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/4/website"><img src="https://opencollective.com/fab/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/5/website"><img src="https://opencollective.com/fab/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/6/website"><img src="https://opencollective.com/fab/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/7/website"><img src="https://opencollective.com/fab/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/8/website"><img src="https://opencollective.com/fab/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/fab/organization/9/website"><img src="https://opencollective.com/fab/organization/9/avatar.svg"></a>
+<a href="https://opencollective.com/fab/organization/0/website"><img src="https://opencollective.com/fab/organization/0/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/1/website"><img src="https://opencollective.com/fab/organization/1/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/2/website"><img src="https://opencollective.com/fab/organization/2/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/3/website"><img src="https://opencollective.com/fab/organization/3/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/4/website"><img src="https://opencollective.com/fab/organization/4/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/5/website"><img src="https://opencollective.com/fab/organization/5/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/6/website"><img src="https://opencollective.com/fab/organization/6/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/7/website"><img src="https://opencollective.com/fab/organization/7/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/8/website"><img src="https://opencollective.com/fab/organization/8/avatar.svg"/></a>
+<a href="https://opencollective.com/fab/organization/9/website"><img src="https://opencollective.com/fab/organization/9/avatar.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 #### Individuals
 
-<a href="https://opencollective.com/fab"><img src="https://opencollective.com/fab/individuals.svg?width=890"></a>
+<a href="https://opencollective.com/fab"><img src="https://opencollective.com/fab/individuals.svg?width=890" /></a>
 
 #### Organizations
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.7-alpha.28"
+  "version": "0.0.7-alpha.29"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.7-alpha.29"
+  "version": "0.0.7-alpha.30"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:watch:esm": "yarn tsc --module esnext --outDir build/esm --watch --preserveWatchOutput --pretty | grep .",
     "build:watch:cjs": "yarn tsc --module commonjs --outDir build/lib --watch --preserveWatchOutput > /dev/null",
     "build:watch": "run-p build:watch:*",
-    "clean": "lerna run clean --parallel",
+    "clean": "rm -rf build/{esm,lib} && lerna run clean --parallel",
     "link-all": "lerna exec -- yarn link",
     "prettify": "prettier \"packages/**/*.{js,ts,tsx}\" --write",
     "test": "lerna run test --stream --parallel",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,66 @@ USAGE
 
 <!-- commands -->
 
+- [`fab build`](#fab-build)
+- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
+- [`fab init`](#fab-init)
+- [`fab package [FILE]`](#fab-package-file)
+- [`fab serve [FILE]`](#fab-serve-file)
+
+## `fab build`
+
+Generate a FAB given the config (usually in fab.config.json5)
+
+```
+USAGE
+  $ fab build
+
+OPTIONS
+  -c, --config=config  [default: fab.config.json5] Path to config file
+  -h, --help           show CLI help
+  --skip-cache         Skip any caching of intermediate build artifacts
+
+EXAMPLES
+  $ fab build
+  $ fab build --config=fab.config.json5
+```
+
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/build.js)_
+
+## `fab deploy [FILE]`
+
+Deploy a FAB to a hosting provider
+
+```
+USAGE
+  $ fab deploy [FILE]
+
+OPTIONS
+  -c, --config=config                                      [default: fab.config.json5] Path to config file
+  -h, --help                                               show CLI help
+
+  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
+                                                           pointing at this URL for assets
+
+  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+  --assets-only                                            Skip server deploy, just upload assets
+
+  --env=env                                                Override production settings with a different environment
+                                                           defined in your FAB config file.
+
+  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
+
+  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+EXAMPLE
+  $ fab deploy fab.zip
+```
+
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -52,5 +111,90 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+
+## `fab init`
+
+Auto-configure a repo for generating FABs
+
+```
+USAGE
+  $ fab init
+
+OPTIONS
+  -c, --config=config         [default: fab.config.json5] Config filename
+  -h, --help                  show CLI help
+  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
+  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
+  --skip-install              Do not attempt to npm install anything
+  --version=version           What NPM version or dist-tag to use for installing FAB packages
+
+EXAMPLES
+  $ fab init
+  $ fab init --config=fab.config.json5
+```
+
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/init.js)_
+
+## `fab package [FILE]`
+
+Package a FAB to be uploaded to a hosting provider manually
+
+```
+USAGE
+  $ fab package [FILE]
+
+OPTIONS
+  -c, --config=config                               [default: fab.config.json5] Path to config file
+  -h, --help                                        show CLI help
+
+  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
+                                                    aws-s3)
+
+  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
+                                                    that need it
+
+  --env=env                                         Override production settings with a different environment defined in
+                                                    your FAB config file.
+
+  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
+
+EXAMPLE
+  $ fab package --target=aws-lambda-edge fab.zip
+```
+
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/package.js)_
+
+## `fab serve [FILE]`
+
+fab serve: Serve a FAB in a local NodeJS Express server
+
+```
+USAGE
+  $ fab serve [FILE]
+
+OPTIONS
+  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
+                             --env.
+
+  -h, --help                 show CLI help
+
+  --cert=cert                SSL certificate to use
+
+  --env=env                  Override production settings with a different environment defined in your FAB config file.
+
+  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
+
+  --key=key                  Key for the SSL Certificate
+
+  --port=port                (required) [default: 3000] Port to use
+
+EXAMPLES
+  $ fab serve fab.zip
+  $ fab serve --port=3001 fab.zip
+  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
+  $ fab serve --env=staging fab.zip
+```
+
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.0.7-alpha.28 darwin-x64 node-v13.12.0
+@fab/cli/0.0.7-alpha.29 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -34,66 +34,7 @@ USAGE
 
 <!-- commands -->
 
-- [`fab build`](#fab-build)
-- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
-- [`fab init`](#fab-init)
-- [`fab package [FILE]`](#fab-package-file)
-- [`fab serve [FILE]`](#fab-serve-file)
-
-## `fab build`
-
-Generate a FAB given the config (usually in fab.config.json5)
-
-```
-USAGE
-  $ fab build
-
-OPTIONS
-  -c, --config=config  [default: fab.config.json5] Path to config file
-  -h, --help           show CLI help
-  --skip-cache         Skip any caching of intermediate build artifacts
-
-EXAMPLES
-  $ fab build
-  $ fab build --config=fab.config.json5
-```
-
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.28/lib/commands/build.js)_
-
-## `fab deploy [FILE]`
-
-Deploy a FAB to a hosting provider
-
-```
-USAGE
-  $ fab deploy [FILE]
-
-OPTIONS
-  -c, --config=config                                      [default: fab.config.json5] Path to config file
-  -h, --help                                               show CLI help
-
-  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
-                                                           pointing at this URL for assets
-
-  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-  --assets-only                                            Skip server deploy, just upload assets
-
-  --env=env                                                Override production settings with a different environment
-                                                           defined in your FAB config file.
-
-  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
-
-  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-EXAMPLE
-  $ fab deploy fab.zip
-```
-
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.28/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -111,90 +52,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
-
-## `fab init`
-
-Auto-configure a repo for generating FABs
-
-```
-USAGE
-  $ fab init
-
-OPTIONS
-  -c, --config=config         [default: fab.config.json5] Config filename
-  -h, --help                  show CLI help
-  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
-  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
-  --skip-install              Do not attempt to npm install anything
-  --version=version           What NPM version or dist-tag to use for installing FAB packages
-
-EXAMPLES
-  $ fab init
-  $ fab init --config=fab.config.json5
-```
-
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.28/lib/commands/init.js)_
-
-## `fab package [FILE]`
-
-Package a FAB to be uploaded to a hosting provider manually
-
-```
-USAGE
-  $ fab package [FILE]
-
-OPTIONS
-  -c, --config=config                               [default: fab.config.json5] Path to config file
-  -h, --help                                        show CLI help
-
-  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
-                                                    aws-s3)
-
-  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
-                                                    that need it
-
-  --env=env                                         Override production settings with a different environment defined in
-                                                    your FAB config file.
-
-  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
-
-EXAMPLE
-  $ fab package --target=aws-lambda-edge fab.zip
-```
-
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.28/lib/commands/package.js)_
-
-## `fab serve [FILE]`
-
-fab serve: Serve a FAB in a local NodeJS Express server
-
-```
-USAGE
-  $ fab serve [FILE]
-
-OPTIONS
-  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
-                             --env.
-
-  -h, --help                 show CLI help
-
-  --cert=cert                SSL certificate to use
-
-  --env=env                  Override production settings with a different environment defined in your FAB config file.
-
-  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
-
-  --key=key                  Key for the SSL Certificate
-
-  --port=port                (required) [default: 3000] Port to use
-
-EXAMPLES
-  $ fab serve fab.zip
-  $ fab serve --port=3001 fab.zip
-  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
-  $ fab serve --env=staging fab.zip
-```
-
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.28/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,66 @@ USAGE
 
 <!-- commands -->
 
+- [`fab build`](#fab-build)
+- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
+- [`fab init`](#fab-init)
+- [`fab package [FILE]`](#fab-package-file)
+- [`fab serve [FILE]`](#fab-serve-file)
+
+## `fab build`
+
+Generate a FAB given the config (usually in fab.config.json5)
+
+```
+USAGE
+  $ fab build
+
+OPTIONS
+  -c, --config=config  [default: fab.config.json5] Path to config file
+  -h, --help           show CLI help
+  --skip-cache         Skip any caching of intermediate build artifacts
+
+EXAMPLES
+  $ fab build
+  $ fab build --config=fab.config.json5
+```
+
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.30/lib/commands/build.js)_
+
+## `fab deploy [FILE]`
+
+Deploy a FAB to a hosting provider
+
+```
+USAGE
+  $ fab deploy [FILE]
+
+OPTIONS
+  -c, --config=config                                      [default: fab.config.json5] Path to config file
+  -h, --help                                               show CLI help
+
+  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
+                                                           pointing at this URL for assets
+
+  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+  --assets-only                                            Skip server deploy, just upload assets
+
+  --env=env                                                Override production settings with a different environment
+                                                           defined in your FAB config file.
+
+  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
+
+  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+EXAMPLE
+  $ fab deploy fab.zip
+```
+
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.30/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -52,5 +111,90 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+
+## `fab init`
+
+Auto-configure a repo for generating FABs
+
+```
+USAGE
+  $ fab init
+
+OPTIONS
+  -c, --config=config         [default: fab.config.json5] Config filename
+  -h, --help                  show CLI help
+  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
+  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
+  --skip-install              Do not attempt to npm install anything
+  --version=version           What NPM version or dist-tag to use for installing FAB packages
+
+EXAMPLES
+  $ fab init
+  $ fab init --config=fab.config.json5
+```
+
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.30/lib/commands/init.js)_
+
+## `fab package [FILE]`
+
+Package a FAB to be uploaded to a hosting provider manually
+
+```
+USAGE
+  $ fab package [FILE]
+
+OPTIONS
+  -c, --config=config                               [default: fab.config.json5] Path to config file
+  -h, --help                                        show CLI help
+
+  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
+                                                    aws-s3)
+
+  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
+                                                    that need it
+
+  --env=env                                         Override production settings with a different environment defined in
+                                                    your FAB config file.
+
+  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
+
+EXAMPLE
+  $ fab package --target=aws-lambda-edge fab.zip
+```
+
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.30/lib/commands/package.js)_
+
+## `fab serve [FILE]`
+
+fab serve: Serve a FAB in a local NodeJS Express server
+
+```
+USAGE
+  $ fab serve [FILE]
+
+OPTIONS
+  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
+                             --env.
+
+  -h, --help                 show CLI help
+
+  --cert=cert                SSL certificate to use
+
+  --env=env                  Override production settings with a different environment defined in your FAB config file.
+
+  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
+
+  --key=key                  Key for the SSL Certificate
+
+  --port=port                (required) [default: 3000] Port to use
+
+EXAMPLES
+  $ fab serve fab.zip
+  $ fab serve --port=3001 fab.zip
+  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
+  $ fab serve --env=staging fab.zip
+```
+
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.30/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.0.7-alpha.29 darwin-x64 node-v13.12.0
+@fab/cli/0.0.7-alpha.30 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -34,66 +34,7 @@ USAGE
 
 <!-- commands -->
 
-- [`fab build`](#fab-build)
-- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
-- [`fab init`](#fab-init)
-- [`fab package [FILE]`](#fab-package-file)
-- [`fab serve [FILE]`](#fab-serve-file)
-
-## `fab build`
-
-Generate a FAB given the config (usually in fab.config.json5)
-
-```
-USAGE
-  $ fab build
-
-OPTIONS
-  -c, --config=config  [default: fab.config.json5] Path to config file
-  -h, --help           show CLI help
-  --skip-cache         Skip any caching of intermediate build artifacts
-
-EXAMPLES
-  $ fab build
-  $ fab build --config=fab.config.json5
-```
-
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/build.js)_
-
-## `fab deploy [FILE]`
-
-Deploy a FAB to a hosting provider
-
-```
-USAGE
-  $ fab deploy [FILE]
-
-OPTIONS
-  -c, --config=config                                      [default: fab.config.json5] Path to config file
-  -h, --help                                               show CLI help
-
-  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
-                                                           pointing at this URL for assets
-
-  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-  --assets-only                                            Skip server deploy, just upload assets
-
-  --env=env                                                Override production settings with a different environment
-                                                           defined in your FAB config file.
-
-  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
-
-  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-EXAMPLE
-  $ fab deploy fab.zip
-```
-
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -111,90 +52,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
-
-## `fab init`
-
-Auto-configure a repo for generating FABs
-
-```
-USAGE
-  $ fab init
-
-OPTIONS
-  -c, --config=config         [default: fab.config.json5] Config filename
-  -h, --help                  show CLI help
-  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
-  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
-  --skip-install              Do not attempt to npm install anything
-  --version=version           What NPM version or dist-tag to use for installing FAB packages
-
-EXAMPLES
-  $ fab init
-  $ fab init --config=fab.config.json5
-```
-
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/init.js)_
-
-## `fab package [FILE]`
-
-Package a FAB to be uploaded to a hosting provider manually
-
-```
-USAGE
-  $ fab package [FILE]
-
-OPTIONS
-  -c, --config=config                               [default: fab.config.json5] Path to config file
-  -h, --help                                        show CLI help
-
-  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
-                                                    aws-s3)
-
-  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
-                                                    that need it
-
-  --env=env                                         Override production settings with a different environment defined in
-                                                    your FAB config file.
-
-  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
-
-EXAMPLE
-  $ fab package --target=aws-lambda-edge fab.zip
-```
-
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/package.js)_
-
-## `fab serve [FILE]`
-
-fab serve: Serve a FAB in a local NodeJS Express server
-
-```
-USAGE
-  $ fab serve [FILE]
-
-OPTIONS
-  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
-                             --env.
-
-  -h, --help                 show CLI help
-
-  --cert=cert                SSL certificate to use
-
-  --env=env                  Override production settings with a different environment defined in your FAB config file.
-
-  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
-
-  --key=key                  Key for the SSL Certificate
-
-  --port=port                (required) [default: 3000] Port to use
-
-EXAMPLES
-  $ fab serve fab.zip
-  $ fab serve --port=3001 fab.zip
-  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
-  $ fab serve --env=staging fab.zip
-```
-
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.0.7-alpha.29/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "oclif"
@@ -34,8 +34,8 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
-    "@fab/server": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
+    "@fab/server": "0.0.7-alpha.29",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "oclif"
@@ -34,8 +34,8 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
-    "@fab/server": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
+    "@fab/server": "0.0.7-alpha.30",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",

--- a/packages/cli/src/actions/Generator.ts
+++ b/packages/cli/src/actions/Generator.ts
@@ -17,9 +17,9 @@ export class Generator {
     const invalid_reason = proto_fab.errorsPreventingCompilation()
     if (invalid_reason) {
       throw new BuildFailedError(`FAB is not ready for compilation.
-${invalid_reason}
-You might need to add @fab/rewire-assets to your 'build' config. See https://fab.dev/packages/rewire-assets for more information about what this module is and why it's needed.
-`)
+        ${invalid_reason}
+        You might need to add @fab/rewire-assets to your 'build' config. See https://fab.dev/packages/rewire-assets for more information about what this module is and why it's needed.
+      `)
     }
 
     log.time(`Writing all files to .fab/build`)

--- a/packages/cli/src/actions/Initializer/constants.ts
+++ b/packages/cli/src/actions/Initializer/constants.ts
@@ -7,6 +7,7 @@ import { BuildConfig } from '@fab/core'
 export enum KnownFrameworkTypes {
   CreateReactApp,
   Next9,
+  Gatsby,
 }
 
 export type FrameworkInfo = {
@@ -63,6 +64,23 @@ export const Frameworks: {
       '@fab/rewire-assets': {},
     },
   },
+  [KnownFrameworkTypes.Gatsby]: {
+    name: 'Gatbsy JS',
+    scripts: {
+      'build:fab': 'npm run build && npm run fab:build',
+      'fab:build': 'fab build',
+      'fab:serve': 'fab serve fab.zip',
+    },
+    plugins: {
+      '@fab/input-static': {
+        dir: 'public',
+      },
+      '@fab/serve-html': {
+        fallback: false,
+      },
+      '@fab/rewire-assets': {},
+    },
+  },
   [KnownFrameworkTypes.Next9]: {
     name: 'NextJS v9+',
     scripts: {
@@ -106,7 +124,9 @@ export const Frameworks: {
     },
   },
 }
+
 export const FRAMEWORK_NAMES = Object.values(Frameworks).map((f) => f.name)
+
 export const BASE_CONFIG: string = `// For more information, see https://fab.dev/kb/configuration
 {
   plugins: {

--- a/packages/cli/src/actions/Initializer/constants.ts
+++ b/packages/cli/src/actions/Initializer/constants.ts
@@ -1,0 +1,140 @@
+import path from 'path'
+import fs from 'fs-extra'
+import { FabInitError } from '../../errors'
+import { log } from '../../helpers'
+import { BuildConfig } from '@fab/core'
+
+export enum KnownFrameworkTypes {
+  CreateReactApp,
+  Next9,
+}
+
+export type FrameworkInfo = {
+  name: string
+  plugins: BuildConfig
+  scripts: { [name: string]: string }
+  customConfig?: (root_dir: string) => void
+}
+export const DEFAULT_DEPS = ['@fab/cli', '@fab/server']
+export const GITIGNORE_LINES = ['/.fab', '/fab.zip']
+export const GUESSED_OUTPUT_DIRS = ['build', 'dist', 'public', 'out']
+export const OUTPUT_DIR_EXAMPLES =
+  GUESSED_OUTPUT_DIRS.slice(0, GUESSED_OUTPUT_DIRS.length - 1)
+    .map((dir) => `💛${dir}💛`)
+    .join(', ') + ` or 💛${GUESSED_OUTPUT_DIRS.slice(-1)}💛`
+
+export function STATIC_SITE(build_cmd: string, found_output_dir: string) {
+  return {
+    name: 'Static Site',
+    scripts: {
+      'build:fab': `${build_cmd} && npm run fab:build`,
+      'fab:build': 'fab build',
+      'fab:serve': 'fab serve fab.zip',
+    },
+    plugins: {
+      '@fab/input-static': {
+        dir: found_output_dir,
+      },
+      '@fab/serve-html': {
+        fallback: '/index.html',
+      },
+      '@fab/rewire-assets': {},
+    },
+  }
+}
+
+export const Frameworks: {
+  [key in KnownFrameworkTypes]: FrameworkInfo
+} = {
+  [KnownFrameworkTypes.CreateReactApp]: {
+    name: 'Create React App',
+    scripts: {
+      'build:fab': 'npm run build && npm run fab:build',
+      'fab:build': 'fab build',
+      'fab:serve': 'fab serve fab.zip',
+    },
+    plugins: {
+      '@fab/input-static': {
+        dir: 'build',
+      },
+      '@fab/serve-html': {
+        fallback: '/index.html',
+      },
+      '@fab/rewire-assets': {},
+    },
+  },
+  [KnownFrameworkTypes.Next9]: {
+    name: 'NextJS v9+',
+    scripts: {
+      // Potentially, we should clear the .next dir before building, to make sure
+      // this FAB isn't publishing anything from a previous build.
+      'build:fab': 'npm run build && npm run fab:build',
+      'fab:build': 'fab build',
+      'fab:serve': 'fab serve fab.zip',
+    },
+    plugins: {
+      '@fab/input-nextjs': {
+        dir: '.next',
+      },
+      '@fab/serve-html': {
+        fallback: false,
+      },
+      '@fab/rewire-assets': {},
+    },
+    async customConfig(root_dir: string) {
+      const config_path = path.join(root_dir, 'next.config.js')
+      if (await fs.pathExists(config_path)) {
+        const next_config = require(config_path)
+        if (next_config.target !== 'serverless') {
+          throw new FabInitError(
+            `Your NextJS project needs to be configured for a serverless build.
+            ${
+              next_config.target
+                ? `Add 💛target: 'serverless'💛 to your 💛next.config.js💛 file.`
+                : `Currently your app is configured to build in 💛${next_config.target ||
+                    'server'}💛 mode.
+                Update this in your 💛next.config.js💛 by setting 💛target: 'serverless'💛`
+            }`
+          )
+        } else {
+          log(`Your app is already configured for a severless build. Proceeding.`)
+        }
+      } else {
+        log(`No 💛next.config.js💛 found, adding one to set 💛target: 'serverless'💛`)
+        await fs.writeFile(config_path, `module.exports = {\n  target: 'serverless'\n}\n`)
+      }
+    },
+  },
+}
+export const FRAMEWORK_NAMES = Object.values(Frameworks).map((f) => f.name)
+export const BASE_CONFIG: string = `// For more information, see https://fab.dev/kb/configuration
+{
+  plugins: {
+    // This section defines your build & runtime toolchains. See https://fab.dev/kb/plugins
+  },
+  settings: {
+    // This section defines the variables that are injected, depending on environment.
+    // See https://fab.dev/kb/settings for more info.
+    production: {
+      // This environment is special. These variables get compiled into the FAB itself,
+      // allowing for many production-specific optimisations. See https://fab.dev/kb/production
+      // Example setting:
+      // API_URL: 'https://api.example.com/graphql'
+    },
+  },
+  deploy: {
+    // For manual (command-line) deploys, add configuration here.
+    // • See https://fab.dev/kb/deploying for more info.
+    // For automatic deploys (triggered by git push), we recommend using Linc:
+    // • See https://linc.sh/docs/automatic-deploys for setup instructions.
+  }
+}
+`
+type StringMap = {
+  [key: string]: string
+}
+export type PackageJson = {
+  scripts?: StringMap
+  dependencies?: StringMap
+  devDependencies?: StringMap
+}

--- a/packages/cli/src/actions/Initializer/index.ts
+++ b/packages/cli/src/actions/Initializer/index.ts
@@ -4,149 +4,22 @@ import path from 'path'
 import semver from 'semver'
 import execa from 'execa'
 
-import { BuildConfig } from '@fab/core'
-
-import { FabInitError } from '../errors'
-import { confirm, log, prompt } from '../helpers'
-import JSON5Config from '../helpers/JSON5Config'
-
-enum KnownFrameworkTypes {
-  CreateReactApp,
-  Next9,
-}
-
-type FrameworkInfo = {
-  name: string
-  plugins: BuildConfig
-  scripts: { [name: string]: string }
-  customConfig?: (root_dir: string) => void
-}
-
-const DEFAULT_DEPS = ['@fab/cli', '@fab/server']
-const GITIGNORE_LINES = ['/.fab', '/fab.zip']
-const GUESSED_OUTPUT_DIRS = ['build', 'dist', 'public', 'out']
-const OUTPUT_DIR_EXAMPLES =
-  GUESSED_OUTPUT_DIRS.slice(0, GUESSED_OUTPUT_DIRS.length - 1)
-    .map((dir) => `💛${dir}💛`)
-    .join(', ') + ` or 💛${GUESSED_OUTPUT_DIRS.slice(-1)}💛`
-
-function STATIC_SITE(build_cmd: string, found_output_dir: string) {
-  return {
-    name: 'Static Site',
-    scripts: {
-      'build:fab': `${build_cmd} && npm run fab:build`,
-      'fab:build': 'fab build',
-      'fab:serve': 'fab serve fab.zip',
-    },
-    plugins: {
-      '@fab/input-static': {
-        dir: found_output_dir,
-      },
-      '@fab/serve-html': {
-        fallback: '/index.html',
-      },
-      '@fab/rewire-assets': {},
-    },
-  }
-}
-
-const Frameworks: {
-  [key in KnownFrameworkTypes]: FrameworkInfo
-} = {
-  [KnownFrameworkTypes.CreateReactApp]: {
-    name: 'Create React App',
-    scripts: {
-      'build:fab': 'npm run build && npm run fab:build',
-      'fab:build': 'fab build',
-      'fab:serve': 'fab serve fab.zip',
-    },
-    plugins: {
-      '@fab/input-static': {
-        dir: 'build',
-      },
-      '@fab/serve-html': {
-        fallback: '/index.html',
-      },
-      '@fab/rewire-assets': {},
-    },
-  },
-  [KnownFrameworkTypes.Next9]: {
-    name: 'NextJS v9+',
-    scripts: {
-      // Potentially, we should clear the .next dir before building, to make sure
-      // this FAB isn't publishing anything from a previous build.
-      'build:fab': 'npm run build && npm run fab:build',
-      'fab:build': 'fab build',
-      'fab:serve': 'fab serve fab.zip',
-    },
-    plugins: {
-      '@fab/input-nextjs': {
-        dir: '.next',
-      },
-      '@fab/serve-html': {
-        fallback: false,
-      },
-      '@fab/rewire-assets': {},
-    },
-    async customConfig(root_dir: string) {
-      const config_path = path.join(root_dir, 'next.config.js')
-      if (await fs.pathExists(config_path)) {
-        const next_config = require(config_path)
-        if (next_config.target !== 'serverless') {
-          throw new FabInitError(
-            `Your NextJS project needs to be configured for a serverless build.
-            ${
-              next_config.target
-                ? `Add 💛target: 'serverless'💛 to your 💛next.config.js💛 file.`
-                : `Currently your app is configured to build in 💛${next_config.target ||
-                    'server'}💛 mode.
-                Update this in your 💛next.config.js💛 by setting 💛target: 'serverless'💛`
-            }`
-          )
-        } else {
-          log(`Your app is already configured for a severless build. Proceeding.`)
-        }
-      } else {
-        log(`No 💛next.config.js💛 found, adding one to set 💛target: 'serverless'💛`)
-        await fs.writeFile(config_path, `module.exports = {\n  target: 'serverless'\n}\n`)
-      }
-    },
-  },
-}
-const FRAMEWORK_NAMES = Object.values(Frameworks).map((f) => f.name)
-
-const BASE_CONFIG: string = `// For more information, see https://fab.dev/kb/configuration
-{
-  plugins: {
-    // This section defines your build & runtime toolchains. See https://fab.dev/kb/plugins
-  },
-  settings: {
-    // This section defines the variables that are injected, depending on environment.
-    // See https://fab.dev/kb/settings for more info.
-    production: {
-      // This environment is special. These variables get compiled into the FAB itself,
-      // allowing for many production-specific optimisations. See https://fab.dev/kb/production
-      // Example setting:
-      // API_URL: 'https://api.example.com/graphql'
-    },
-  },
-  deploy: {
-    // For manual (command-line) deploys, add configuration here.
-    // • See https://fab.dev/kb/deploying for more info.
-    // For automatic deploys (triggered by git push), we recommend using Linc:
-    // • See https://linc.sh/docs/automatic-deploys for setup instructions.
-  }
-}
-`
-
-type StringMap = {
-  [key: string]: string
-}
-type PackageJson = {
-  scripts?: StringMap
-  dependencies?: StringMap
-  devDependencies?: StringMap
-}
+import { FabInitError } from '../../errors'
+import { confirm, log, prompt } from '../../helpers'
+import JSON5Config from '../../helpers/JSON5Config'
+import {
+  BASE_CONFIG,
+  DEFAULT_DEPS,
+  FRAMEWORK_NAMES,
+  FrameworkInfo,
+  Frameworks,
+  GITIGNORE_LINES,
+  GUESSED_OUTPUT_DIRS,
+  KnownFrameworkTypes,
+  OUTPUT_DIR_EXAMPLES,
+  PackageJson,
+  STATIC_SITE,
+} from './constants'
 
 const confirmAndRespond = async (
   message: string,

--- a/packages/cli/src/actions/Initializer/index.ts
+++ b/packages/cli/src/actions/Initializer/index.ts
@@ -231,6 +231,8 @@ export default class Initializer {
       return KnownFrameworkTypes.Next9
     } else if (await this.isCreateReactApp(package_json)) {
       return KnownFrameworkTypes.CreateReactApp
+    } else if (await this.isGatsby(package_json)) {
+      return KnownFrameworkTypes.Gatsby
     }
     return null
   }
@@ -267,6 +269,14 @@ export default class Initializer {
     }
 
     return true
+  }
+
+  static async isGatsby(package_json: PackageJson) {
+    const gatsby_dep =
+      package_json.dependencies?.['gatsby'] || package_json.devDependencies?.['gatsby']
+    if (!gatsby_dep) return false
+
+    return package_json.scripts?.build?.match(/gatsby build/)
   }
 
   private static async installDependencies(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/core",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "private": false,
   "description": "Common code for all FAB projects",
   "homepage": "https://github.com/fab-spec/fab",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/core",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "private": false,
   "description": "Common code for all FAB projects",
   "homepage": "https://github.com/fab-spec/fab",

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-lambda",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.14",
     "deterministic-zip": "^1.1.0",

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-lambda",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.14",
     "deterministic-zip": "^1.1.0",

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-s3",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Uploads FAB assets to AWS S3",
   "keywords": [
     "fab"
@@ -29,7 +29,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/node": "^12.12.14",
     "aws-sdk": "^2.655.0",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-s3",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Uploads FAB assets to AWS S3",
   "keywords": [
     "fab"
@@ -29,7 +29,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/node": "^12.12.14",
     "aws-sdk": "^2.655.0",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-cf-workers",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/node": "^12.12.14",
     "cross-fetch": "^3.0.4",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-cf-workers",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/node": "^12.12.14",
     "cross-fetch": "^3.0.4",
     "fs-extra": "^9.0.0",

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/node": "^12.12.14",
     "@types/path-to-regexp": "^1.7.0",
     "acorn": "^7.1.0",

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/node": "^12.12.14",
     "@types/path-to-regexp": "^1.7.0",
     "acorn": "^7.1.0",

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-static",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Module to handle a directory of HTML & assets",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/node": "^12.12.14",
     "fs-extra": "^8.1.0",
     "globby": "^10"

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-static",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Module to handle a directory of HTML & assets",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/node": "^12.12.14",
     "fs-extra": "^8.1.0",
     "globby": "^10"

--- a/packages/rewire-assets/package.json
+++ b/packages/rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/rewire-assets",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/istextorbinary": "^2.3.0",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12.12.14",

--- a/packages/rewire-assets/package.json
+++ b/packages/rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/rewire-assets",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/istextorbinary": "^2.3.0",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12.12.14",

--- a/packages/rewire-assets/src/build.ts
+++ b/packages/rewire-assets/src/build.ts
@@ -59,12 +59,11 @@ export async function build(
   const renamed_assets: RenamedAssets = {}
   for (const filename of to_rename) {
     const contents = proto_fab.files.get(filename)!
-    const hash = hasha(contents, { algorithm: 'md5' }).slice(0, 9)
     const immutable = !!immutable_regexp.exec(filename)
-    const extname = path.extname(filename)
-    const asset_path = `/_assets${
-      immutable ? filename : filename.slice(0, -1 * extname.length) + '.' + hash + extname
-    }`
+    const fingerprinted_name = immutable
+      ? filename
+      : getFingerprintedName(contents, filename)
+    const asset_path = `/_assets${fingerprinted_name}`
 
     renamed_assets[filename] = {
       asset_path,
@@ -77,4 +76,12 @@ export async function build(
   }
 
   proto_fab.metadata.rewire_assets = { inlined_assets, renamed_assets }
+}
+
+const getFingerprintedName = (contents: Buffer, filename: string) => {
+  const hash = hasha(contents, { algorithm: 'md5' }).slice(0, 9)
+  const extname = path.extname(filename)
+  return extname
+    ? `${filename.slice(0, -1 * extname.length)}.${hash}${extname}`
+    : `${filename}_${hash}`
 }

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/sandbox-node-vm",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "FAB runtime sandbox using Node's 'vm'",
   "keywords": [
     "fab"
@@ -28,7 +28,7 @@
     "prepack": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "cross-fetch": "^3.0.4"
   },
   "publishConfig": {

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/sandbox-node-vm",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "FAB runtime sandbox using Node's 'vm'",
   "keywords": [
     "fab"
@@ -28,7 +28,7 @@
     "prepack": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "cross-fetch": "^3.0.4"
   },
   "publishConfig": {

--- a/packages/serve-html/package.json
+++ b/packages/serve-html/package.json
@@ -32,10 +32,9 @@
   "dependencies": {
     "@fab/core": "0.0.7-alpha.29",
     "@types/cheerio": "^0.22.15",
-    "@types/mustache": "^0.8.32",
     "@types/node": "^12.12.14",
     "cheerio": "^1.0.0-rc.3",
-    "mustache": "^3.2.0"
+    "micromustache": "^7.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/serve-html/package.json
+++ b/packages/serve-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/serve-html",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "Module to render static HTML files with FAB injections",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
     "@types/cheerio": "^0.22.15",
     "@types/node": "^12.12.14",
     "cheerio": "^1.0.0-rc.3",

--- a/packages/serve-html/package.json
+++ b/packages/serve-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/serve-html",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "Module to render static HTML files with FAB injections",
   "keywords": [
     "fab"
@@ -30,7 +30,7 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
     "@types/cheerio": "^0.22.15",
     "@types/mustache": "^0.8.32",
     "@types/node": "^12.12.14",

--- a/packages/serve-html/src/build.ts
+++ b/packages/serve-html/src/build.ts
@@ -1,7 +1,7 @@
 import { ProtoFab } from '@fab/core'
 import { ServeHtmlArgs, ServeHtmlMetadata, ServerHtmls } from './types'
 import cheerio from 'cheerio'
-import mustache from 'mustache'
+import { tokenize } from 'micromustache'
 import { DEFAULT_INJECTIONS } from './constants'
 import { addInjectionPoint } from './injections/env'
 import { _log, InvalidConfigError } from '@fab/cli'
@@ -26,7 +26,7 @@ export async function build(args: ServeHtmlArgs, proto_fab: ProtoFab<ServeHtmlMe
         contents
           .toString('utf8')
           .replace(/{{{|{{/g, (match) =>
-            match.length === 3 ? `{{{ OPEN_TRIPLE }}}` : `{{{ OPEN_DOUBLE }}}`
+            match.length === 3 ? `{{ OPEN_TRIPLE }}` : `{{ OPEN_DOUBLE }}`
           )
       )
 
@@ -36,7 +36,12 @@ export async function build(args: ServeHtmlArgs, proto_fab: ProtoFab<ServeHtmlMe
       // $('script').attr('nonce', '{{ FAB_NONCE }}')
 
       const template = $.html()
-      htmls[filename] = mustache.parse(template)
+      htmls[filename] = tokenize(template)
+      // console.log(filename)
+      // console.log(htmls[filename].strings.map(str => str.slice(0, 100)))
+      // console.log(htmls[filename].varNames)
+      log(`💚  ✔💚 🖤${filename}🖤`)
+      // await new Promise((res) => setTimeout(res, 200))
     }
   }
 

--- a/packages/serve-html/src/injections/env.ts
+++ b/packages/serve-html/src/injections/env.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INJECTIONS } from '../constants'
 import { EnvInjectionConfig } from '../types'
 
 export function addInjectionPoint($: CheerioStatic) {
-  $('head').prepend('{{{ FAB_ENV_INJECTION }}}')
+  $('head').prepend('{{ FAB_ENV_INJECTION }}')
 }
 
 export function generateReplacements(config: EnvInjectionConfig, settings: FabSettings) {

--- a/packages/serve-html/src/types.ts
+++ b/packages/serve-html/src/types.ts
@@ -1,4 +1,5 @@
 import { PluginArgs, PluginMetadata } from '@fab/core'
+import { ITokens } from 'micromustache'
 
 export type EnvInjectionConfig = {
   name?: string
@@ -17,9 +18,8 @@ export interface ServeHtmlArgs extends PluginArgs {
   fallback?: string | boolean
 }
 
-export type ServerHtml = Array<Array<[string, string, number, number]>>
 export type ServerHtmls = {
-  [path: string]: ServerHtml
+  [path: string]: ITokens
 }
 export interface ServeHtmlMetadata extends PluginMetadata {
   serve_html: {

--- a/packages/serve-html/test/build.test.ts
+++ b/packages/serve-html/test/build.test.ts
@@ -35,11 +35,13 @@ describe('Build time', () => {
     await build({}, proto_fab)
     const htmls = proto_fab.metadata.serve_html.htmls
     expect(Object.keys(htmls)).to.deep.equal(['/index.html'])
-    expect(htmls['/index.html'].map((tokens) => tokens[1])).to.deep.equal([
-      '<html><head>',
-      'FAB_ENV_INJECTION',
-      '<title>HTML Test</title></head><body>here</body></html>',
-    ])
+    expect(htmls['/index.html']).to.deep.equal({
+      strings: [
+        '<html><head>',
+        '<title>HTML Test</title></head><body>here</body></html>',
+      ],
+      varNames: ['FAB_ENV_INJECTION'],
+    })
   })
 
   it(`should not make room for FAB_SETTINGS if 'env' isn't passed`, async () => {
@@ -56,9 +58,11 @@ describe('Build time', () => {
     )
     const htmls = proto_fab.metadata.serve_html.htmls
     expect(Object.keys(htmls)).to.deep.equal(['/index.html'])
-    expect(htmls['/index.html'].map((tokens) => tokens[1])).to.deep.equal([
-      '<html><head><title>HTML Test</title></head><body>here</body></html>',
-    ])
+
+    expect(htmls['/index.html']).to.deep.equal({
+      strings: ['<html><head><title>HTML Test</title></head><body>here</body></html>'],
+      varNames: [],
+    })
   })
 
   it(`should explode if you try to use an injection it doesn't know about`, async () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/server",
-  "version": "0.0.7-alpha.29",
+  "version": "0.0.7-alpha.30",
   "description": "NodeJS FAB Server",
   "keywords": [
     "fab"
@@ -29,8 +29,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.29",
-    "@fab/sandbox-node-vm": "0.0.7-alpha.29",
+    "@fab/core": "0.0.7-alpha.30",
+    "@fab/sandbox-node-vm": "0.0.7-alpha.30",
     "@fly/v8env": "^0.54.0",
     "@types/concat-stream": "^1.6.0",
     "@types/express": "^4.17.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/server",
-  "version": "0.0.7-alpha.28",
+  "version": "0.0.7-alpha.29",
   "description": "NodeJS FAB Server",
   "keywords": [
     "fab"
@@ -29,8 +29,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/core": "0.0.7-alpha.28",
-    "@fab/sandbox-node-vm": "0.0.7-alpha.28",
+    "@fab/core": "0.0.7-alpha.29",
+    "@fab/sandbox-node-vm": "0.0.7-alpha.29",
     "@fly/v8env": "^0.54.0",
     "@types/concat-stream": "^1.6.0",
     "@types/express": "^4.17.2",

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -16,6 +16,9 @@ describe('Create React App E2E Test', () => {
   it('should create a new CRA project', async () => {
     cwd = await getWorkingDir('cra-test', !process.env.FAB_E2E_SKIP_CREATE)
     const { stdout: current_sha } = await cmd(`git rev-parse --short HEAD`, { cwd })
+    const { stdout: current_branch } = await cmd(`git rev-parse --abbrev-ref HEAD`, {
+      cwd,
+    })
     if (process.env.FAB_E2E_SKIP_CREATE) {
       console.log({ cwd })
       await shell(`git reset --hard`, { cwd })
@@ -35,7 +38,7 @@ describe('Create React App E2E Test', () => {
     expect(files).toMatch('package.json')
     // Add the FAB project's current commit SHA to index.js for debugging
     await shell(
-      `echo "\\nconsole.log('[FAB CI] Create React App (${current_sha})')" >> src/index.js`,
+      `echo "\\nconsole.log('[FAB CI] Create React App — Branch ${current_branch} (${current_sha})')" >> src/index.js`,
       { cwd, shell: true }
     )
   })

--- a/tests/e2e/nextjs.test.ts
+++ b/tests/e2e/nextjs.test.ts
@@ -12,6 +12,9 @@ describe('Create React App E2E Test', () => {
   it('should create a new CRA project', async () => {
     cwd = await getWorkingDir('nextjs-test', !process.env.FAB_E2E_SKIP_CREATE)
     const { stdout: current_sha } = await cmd(`git rev-parse --short HEAD`, { cwd })
+    const { stdout: current_branch } = await cmd(`git rev-parse --abbrev-ref HEAD`, {
+      cwd,
+    })
     if (process.env.FAB_E2E_SKIP_CREATE) {
       console.log({ cwd })
       await shell(`git reset --hard`, { cwd })
@@ -31,7 +34,7 @@ describe('Create React App E2E Test', () => {
     expect(files).toMatch('package.json')
     // Add the FAB project's current commit SHA to index.js for debugging
     await shell(
-      `echo "\\nconsole.log('[FAB CI] NextJS (${current_sha})')" >> pages/index.js`,
+      `echo "\\nconsole.log('[FAB CI] NextJS — Branch ${current_branch} (${current_sha})')" >> pages/index.js`,
       { cwd, shell: true }
     )
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,11 +1275,6 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/mustache@^0.8.32":
-  version "0.8.32"
-  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-0.8.32.tgz#7db3b81f2bf450bd38805f596d20eca97c4ed595"
-  integrity sha512-RTVWV485OOf4+nO2+feurk0chzHkSjkjALiejpHltyuMf/13fGymbbNNFrSKdSSUg1TIwzszXdWsVirxgqYiFA==
-
 "@types/nanoid@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/nanoid/-/nanoid-2.1.0.tgz#41edfda78986e9127d0dc14de982de766f994020"
@@ -6084,6 +6079,11 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromustache@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/micromustache/-/micromustache-7.1.0.tgz#53eebe9a4fe0ac9b9990535e090f797e2934d5e1"
+  integrity sha512-DXUYQI8qPsfOx3AkiGzyOx0cn7NgCqFYsV0Asa/ZQUna2Er4mwpAdA9iANA92WYvUowHf+jBsVvIZxiRe1z1Ig==
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -6348,11 +6348,6 @@ multimatch@^3.0.0:
     array-union "^1.0.2"
     arrify "^1.0.1"
     minimatch "^3.0.4"
-
-mustache@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-3.2.0.tgz#1c68e0bf77817a92e8a9216e35c53bbb342345f6"
-  integrity sha512-n5de2nQ1g2iz3PO9cmq/ZZx3W7glqjf0kavThtqfuNlZRllgU2a2Q0jWoQy3BloT5A6no7sjCTHBVn1rEKjx1Q==
 
 mute-stream@0.0.7:
   version "0.0.7"


### PR DESCRIPTION
Right now, `fab init` only auto-detects the `public` directory if a gatsby build has been run, which is ok, but has implications for Linc.

Bigger problem is large gatsby sites. So looking at fixing https://github.com/fab-spec/fab/issues/77 as part of this.

Also, Gatsby paths break on https://github.com/reactjs/reactjs.org so we gotta fix that first.