### PR TITLE
On demand installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ They **unify static sites, single page applications (SPAs), server-side renderin
 
 ## What can I can use FABs for?
 
-Because FABs include [server-side JavaScript](https://fab.dev/kb/fab-structure) capabilities but deploy as easily as [uploading a ZIP file](https://fab.dev/guides/deploying), you can start to add server-side logic without the complexity of managing servers. Making it easy to do things like:
+Because FABs include [server-side JavaScript](https://fab.dev/kb/fab-structure) capabilities but deploy [with a single command](https://fab.dev/guides/deploying), you can start to add server-side logic without the complexity of managing servers. Making it easy to do things like:
 
-- Deploy a server-rendered NextJS app to Cloudflare workers.
-- Add redirect rules to a Create React App project, without ejecting.
+- Deploy anything, even a server-rendered NextJS app, to Cloudflare workers.
+- Add server-side logic like redirects & proxying to a Create React App project, without ejecting.
 - Use Gatsby to generate a logged-in vs logged-out homepage and dynamically choose which one to serve to each user.
 - Guard your application against unauthenticated users, by checking a cookie before you serve any JS or HTML.
 - Deploy every commit to a unique URL to share your progress with colleagues.

--- a/packages/actions/src/Deployer.ts
+++ b/packages/actions/src/Deployer.ts
@@ -142,7 +142,7 @@ export default class Deployer {
 
   private static loadPackage<T>(provider: string, fn: string): T {
     const pkg = HOSTING_PROVIDERS[provider].package_name
-    const loaded = loadModule(pkg, [process.cwd()])
+    const loaded = loadModule(log, pkg)
 
     if (typeof loaded[fn] !== 'function') {
       throw new FabDeployError(`${pkg} doesn't export a '${fn}' method!`)

--- a/packages/actions/src/Deployer.ts
+++ b/packages/actions/src/Deployer.ts
@@ -5,15 +5,15 @@ import {
   ENV_VAR_SYNTAX,
   FabDeployerExports,
   FabSettings,
-  DeployFn,
   HOSTING_PROVIDERS,
 } from '@fab/core'
 import {
-  JSON5Config,
   _log,
   FabDeployError,
   InvalidConfigError,
-  loadModule,
+  JSON5Config,
+  loadOrInstallModule,
+  loadOrInstallModules,
 } from '@fab/cli'
 
 const log = _log('Deployer')
@@ -50,7 +50,7 @@ export default class Deployer {
     )
     log(`Creating package directory 💛${package_dir}💛:`)
     await fs.ensureDir(package_dir)
-    log(`💚✔💚 Done.`)
+    log.tick(`Done.`)
 
     if (assets_provider) {
       const deployed_url = await this.deployAssetsAndServer(
@@ -69,7 +69,7 @@ export default class Deployer {
         `💚NOTE:💚 skipping assets deploy, using 💛${assets_already_deployed_at}💛 for assets URL.`
       )
 
-      const server_deployer = this.loadPackage<FabDeployerExports<any>>(
+      const server_deployer = await this.loadPackage<FabDeployerExports<any>>(
         server_provider,
         'deployServer'
       )
@@ -97,7 +97,7 @@ export default class Deployer {
     assets_only: boolean
   ) {
     if (server_provider === assets_provider) {
-      const deployer = this.loadPackage<FabDeployerExports<any>>(
+      const deployer = await this.loadPackage<FabDeployerExports<any>>(
         assets_provider,
         'deployBoth'
       )
@@ -110,15 +110,10 @@ export default class Deployer {
       )
     }
 
-    const assets_deployer = this.loadPackage<FabDeployerExports<any>>(
-      assets_provider,
-      'deployAssets'
-    )
-
-    const server_deployer = this.loadPackage<FabDeployerExports<any>>(
-      server_provider,
-      'deployServer'
-    )
+    const [assets_deployer, server_deployer] = await this.loadTwoPackages<
+      FabDeployerExports<any>,
+      FabDeployerExports<any>
+    >(assets_provider, 'deployAssets', server_provider, 'deployServer')
 
     const assets_url = await assets_deployer.deployAssets!(
       file_path,
@@ -140,15 +135,35 @@ export default class Deployer {
     )
   }
 
-  private static loadPackage<T>(provider: string, fn: string): T {
+  private static async loadPackage<T>(provider: string, fn: string): Promise<T> {
     const pkg = HOSTING_PROVIDERS[provider].package_name
-    const loaded = loadModule(log, pkg)
+    const loaded = await loadOrInstallModule(log, pkg)
 
     if (typeof loaded[fn] !== 'function') {
       throw new FabDeployError(`${pkg} doesn't export a '${fn}' method!`)
     }
 
     return loaded as T
+  }
+
+  private static async loadTwoPackages<T, U>(
+    providerA: string,
+    fnA: string,
+    providerB: string,
+    fnB: string
+  ): Promise<[T, U]> {
+    const pkgA = HOSTING_PROVIDERS[providerA].package_name
+    const pkgB = HOSTING_PROVIDERS[providerB].package_name
+    const [loadedA, loadedB] = await loadOrInstallModules(log, [pkgA, pkgB])
+
+    if (typeof loadedA[fnA] !== 'function') {
+      throw new FabDeployError(`${pkgA} doesn't export a '${fnA}' method!`)
+    }
+    if (typeof loadedB[fnB] !== 'function') {
+      throw new FabDeployError(`${pkgB} doesn't export a '${fnB}' method!`)
+    }
+
+    return [loadedA as T, loadedB as U]
   }
 
   private static async deployServer(

--- a/packages/actions/src/Packager.ts
+++ b/packages/actions/src/Packager.ts
@@ -31,7 +31,7 @@ export default class Packager {
 
     const { package_name } = provider
     log(`Loading packager code from ${package_name}`)
-    const packager = loadModule(package_name, [process.cwd()]) as FabPackagerExports<
+    const packager = loadModule(log, package_name) as FabPackagerExports<
       ConfigTypes.Union
     >
     log(`💚✔💚 Done.`)

--- a/packages/actions/src/Packager.ts
+++ b/packages/actions/src/Packager.ts
@@ -34,7 +34,7 @@ export default class Packager {
     const packager = loadModule(log, package_name) as FabPackagerExports<
       ConfigTypes.Union
     >
-    log(`💚✔💚 Done.`)
+    log.tick(`Done.`)
 
     if (env) throw new Error('Not implemented ENV support yet')
     const env_overrides = {}

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('dotenv').config()
 
 require('@oclif/command').run()
 .then(require('@oclif/command/flush'))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@fab/core": "0.1.4-alpha.0",
-    "@fab/server": "0.1.4-alpha.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "@types/semver": "^6.2.0",
     "chalk": "^3.0.0",
     "cli-ux": "^5.4.5",
+    "dotenv": "^8.2.0",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
     "jju": "^1.4.0",
@@ -56,6 +57,7 @@
     "prettier": "^1.19.1",
     "pretty-bytes": "^5.3.0",
     "regex-parser": "^2.2.10",
+    "resolve": "^1.17.0",
     "semver": "^7.1.1",
     "shelljs": "^0.8.3",
     "typescript": "^3.7.5"

--- a/packages/cli/src/Initializer/constants.ts
+++ b/packages/cli/src/Initializer/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_DEPS = ['@fab/cli', '@fab/server', '@fab/actions']
+export const DEFAULT_DEPS = ['@fab/cli', '@fab/actions']
 export const DEPRECATED_PACKAGES = [
   '@fab/static',
   '@fab/compile',

--- a/packages/cli/src/Initializer/index.ts
+++ b/packages/cli/src/Initializer/index.ts
@@ -3,7 +3,14 @@ import pkgUp from 'pkg-up'
 import path from 'path'
 import semver from 'semver'
 
-import { _log, FabInitError, installDependencies, JSON5Config, prompt } from '../'
+import {
+  _log,
+  FabInitError,
+  installDependencies,
+  JSON5Config,
+  prompt,
+  useYarn,
+} from '../'
 import {
   BASE_CONFIG,
   DEFAULT_DEPS,
@@ -15,7 +22,6 @@ import {
 } from './constants'
 import { FRAMEWORK_NAMES, FrameworkInfo, Frameworks, GenericStatic } from './frameworks'
 import { mergeScriptsAfterBuild } from './utils'
-import { useYarn } from '../helpers/modules'
 
 const log = _log('Initializer')
 

--- a/packages/cli/src/Initializer/index.ts
+++ b/packages/cli/src/Initializer/index.ts
@@ -2,9 +2,8 @@ import fs from 'fs-extra'
 import pkgUp from 'pkg-up'
 import path from 'path'
 import semver from 'semver'
-import execa from 'execa'
 
-import { _log, confirm, FabInitError, JSON5Config, prompt } from '../'
+import { _log, FabInitError, installDependencies, JSON5Config, prompt } from '../'
 import {
   BASE_CONFIG,
   DEFAULT_DEPS,
@@ -16,21 +15,9 @@ import {
 } from './constants'
 import { FRAMEWORK_NAMES, FrameworkInfo, Frameworks, GenericStatic } from './frameworks'
 import { mergeScriptsAfterBuild } from './utils'
-const log = _log('Initializer')
+import { useYarn } from '../helpers/modules'
 
-const confirmAndRespond = async (
-  message: string,
-  if_yes: string = `Ok, proceeding...`,
-  if_no: string = `Ok, exiting`
-) => {
-  const response = await confirm(message)
-  if (response) {
-    log(if_yes)
-  } else {
-    log(if_no)
-  }
-  return response
-}
+const log = _log('Initializer')
 
 const promptWithDefault = async (
   message: string,
@@ -82,7 +69,7 @@ export default class Initializer {
             package_json_path
           )}💚`
         )
-        const confirmed = await confirmAndRespond(
+        const confirmed = await log.confirmAndRespond(
           `💛Are you sure you want to configure a FAB here?💛`
         )
         if (!confirmed) return
@@ -98,12 +85,12 @@ export default class Initializer {
     )
     if (!framework) return
 
-    const use_yarn = await fs.pathExists(path.join(root_dir, 'yarn.lock'))
+    const use_yarn = await useYarn(root_dir)
 
     if (this.yes) {
       log.info(`Proceeding...`)
     } else {
-      const confirmed = await confirmAndRespond(`
+      const confirmed = await log.confirmAndRespond(`
         💚Ready to proceed.💚 This process will:
         • Generate a 💛fab.config.json5💛 file for your project
         • Add 💛build:fab💛 and related scripts to your 💛package.json💛
@@ -173,7 +160,7 @@ export default class Initializer {
       `)
 
       const attempt_static =
-        this.yes || (await confirmAndRespond(`Would you like to proceed?`))
+        this.yes || (await log.confirmAndRespond(`Would you like to proceed?`))
       if (!attempt_static) return
 
       return await this.setupStaticFramework(package_json, root_dir)
@@ -276,7 +263,7 @@ export default class Initializer {
       const export_build =
         this.yes || build_cmd === 'npm run export'
           ? true
-          : await confirmAndRespond(`Is this a static (i.e. 💛next export💛) site?`)
+          : await log.confirmAndRespond(`Is this a static (i.e. 💛next export💛) site?`)
       return Frameworks.Next9({ export_build, build_cmd })
     } else {
       return Frameworks.Next9({ export_build: false, build_cmd: 'npm run build' })
@@ -327,11 +314,7 @@ export default class Initializer {
     log(`💚Installing required development dependencies💚:
       ${dependencies.join('\n  ')}
       using 💛${use_yarn ? 'yarn' : 'npm'}💛`)
-    if (use_yarn) {
-      await execa('yarn', ['add', '--dev', ...dependencies], { cwd: root_dir })
-    } else {
-      await execa('npm', ['i', '--save-dev', ...dependencies], { cwd: root_dir })
-    }
+    await installDependencies(use_yarn, dependencies, root_dir)
     log(`
       💚Done!💚
 
@@ -352,7 +335,7 @@ export default class Initializer {
       log.warn(`Existing config has a "plugins" section.`)
       const confirmed =
         (this.yes && log(`Overwriting since -y is set.`)) ||
-        (await confirmAndRespond(
+        (await log.confirmAndRespond(
           `Would you like to overwrite it?`,
           `Ok, overwriting...`,
           `Ok, leaving as-is.`
@@ -381,7 +364,7 @@ export default class Initializer {
       log(`We want to add/overwrite the following lines to your 💛package.json💛:
         💛${JSON.stringify(framework.scripts, null, 2)}💛
       `)
-      const ok = await confirmAndRespond(`Overwrite existing scripts?`)
+      const ok = await log.confirmAndRespond(`Overwrite existing scripts?`)
       if (!ok) return
     }
     await fs.writeFile(

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -5,7 +5,8 @@ import {
   ServerArgs,
   FabServerExports,
 } from '@fab/core'
-import { loadOrInstallModule, log } from '../helpers'
+import { loadOrInstallModule, _log } from '../helpers'
+const log = _log(`Server`)
 
 export default class Serve extends Command {
   static description = 'fab serve: Serve a FAB in a local NodeJS Express server'
@@ -57,6 +58,7 @@ export default class Serve extends Command {
       log.error('ERROR: You must provide a FAB filename to serve.\n')
       this._help()
     }
+    log.announce(`fab serve`)
     const server_pkg = (await loadOrInstallModule(log, '@fab/server'))
       .default as FabServerExports
     const server = server_pkg.createServer(file, flags as ServerArgs)

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -5,7 +5,7 @@ import {
   ServerArgs,
   FabServerExports,
 } from '@fab/core'
-import { log } from '../helpers'
+import { loadOrInstallModule, log } from '../helpers'
 
 export default class Serve extends Command {
   static description = 'fab serve: Serve a FAB in a local NodeJS Express server'
@@ -57,7 +57,8 @@ export default class Serve extends Command {
       log.error('ERROR: You must provide a FAB filename to serve.\n')
       this._help()
     }
-    const server_pkg = require('@fab/server').default as FabServerExports
+    const server_pkg = (await loadOrInstallModule(log, '@fab/server'))
+      .default as FabServerExports
     const server = server_pkg.createServer(file, flags as ServerArgs)
     await server.serve(
       flags['experimental-v8-sandbox'] ? SandboxType.v8isolate : SandboxType.nodeVm

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -58,7 +58,6 @@ export default class Serve extends Command {
       this._help()
     }
     const server_pkg = require('@fab/server').default as FabServerExports
-    console.log({ server_pkg })
     const server = server_pkg.createServer(file, flags as ServerArgs)
     await server.serve(
       flags['experimental-v8-sandbox'] ? SandboxType.v8isolate : SandboxType.nodeVm

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -1,7 +1,24 @@
 import chalk from 'chalk'
-export * from './paths'
 import cli from 'cli-ux'
 import { IPromptOptions } from 'cli-ux/lib/prompt'
+
+export * from './paths'
+export * from './modules'
+
+export const confirmAndRespond = async (
+  log: Logger,
+  message: string,
+  if_yes: string = `Ok, proceeding...`,
+  if_no: string = `Ok, exiting`
+) => {
+  const response = await confirm(message)
+  if (response) {
+    log(if_yes)
+  } else {
+    log(if_no)
+  }
+  return response
+}
 
 function format(str: string, indent = 0, first_line_indent = 0) {
   return (
@@ -75,6 +92,8 @@ export const _log = (full_prefix: string) => {
   log.announce = (str: string) => {
     log(`💎 💚${str}💚 💎`)
   }
+  log.confirmAndRespond = (message: string, if_yes?: string, if_no?: string) =>
+    confirmAndRespond(log, message, if_yes, if_no)
   return log
 }
 
@@ -84,11 +103,4 @@ export const confirm = (message: string) => cli.confirm(format(message))
 export const prompt = (message: string, opts?: IPromptOptions) =>
   cli.prompt(format(message), opts)
 
-export const loadModule = (module_name: string, paths: string[]) => {
-  try {
-    return require(require.resolve(module_name, { paths }))
-  } catch (e) {
-    log.error(`ERROR: FAILED TO LOAD ${module_name}.`)
-    throw e
-  }
-}
+export type Logger = ReturnType<typeof _log>

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -34,6 +34,7 @@ function format(str: string, indent = 0, first_line_indent = 0) {
           return ''
         }
       )
+      .replace(/\.{3}/g, '…')
       .split('\n')
       .map((line) => line.trim())
       .join(`\n${' '.repeat(indent)}`)
@@ -89,11 +90,14 @@ export const _log = (full_prefix: string) => {
   log.note = (str: string) => {
     log(`💚NOTE:💚 ${str}`)
   }
+  log.tick = (str: string, indent: number = 0) => {
+    log(`💚${' '.repeat(indent)}✔💚 ${str}`)
+  }
   log.announce = (str: string) => {
     log(`💎 💚${str}💚 💎`)
   }
   log.confirmAndRespond = (message: string, if_yes?: string, if_no?: string) =>
-    confirmAndRespond(log, message, if_yes, if_no)
+    confirmAndRespond(log, `${prefix} ${message}`, if_yes, if_no)
   return log
 }
 

--- a/packages/cli/src/helpers/modules.ts
+++ b/packages/cli/src/helpers/modules.ts
@@ -24,17 +24,13 @@ export function loadModule(log: Logger, module_name: string, paths?: string[]) {
 
 async function tryLoadingMultiple(module_names: string[], use_execa = false) {
   const attempts: { [name: string]: { module?: any; error?: Error } } = {}
-  console.log({ module_names, use_execa })
   await Promise.all(
     module_names.map(async (name) => {
       try {
         if (use_execa) {
           const this_we_run = `console.log(require.resolve('${name}'))`
-          console.log({ this_we_run })
           const module_path = (await execa(`node`, ['-e', this_we_run])).stdout.trim()
-          console.log({ module_path })
           const module = tryLoading(module_path)
-          console.log({ module })
           attempts[name] = { module }
         } else {
           const module = tryLoading(name)

--- a/packages/cli/src/helpers/modules.ts
+++ b/packages/cli/src/helpers/modules.ts
@@ -1,0 +1,81 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { Logger } from './index'
+import execa from 'execa'
+
+export function useYarn(root_dir: string) {
+  return fs.pathExists(path.join(root_dir, 'yarn.lock'))
+}
+
+function tryLoading(module_name: string, paths?: string[]) {
+  return require(require.resolve(module_name, {
+    paths: paths ? paths : [process.cwd()],
+  }))
+}
+
+export function loadModule(log: Logger, module_name: string, paths?: string[]) {
+  try {
+    return tryLoading(module_name, paths)
+  } catch (e) {
+    log.error(`ERROR: FAILED TO LOAD ${module_name}.`)
+    throw e
+  }
+}
+
+function tryLoadingMultiple(module_names: string[]) {
+  const attempts: { [name: string]: { module?: any; error?: Error } } = {}
+  module_names.forEach((name) => {
+    try {
+      const module = tryLoading(name)
+      attempts[name] = { module }
+    } catch (error) {
+      attempts[name] = { error }
+    }
+  })
+  return attempts
+}
+
+export async function loadOrInstallModule(log: Logger, module_names: string[]) {
+  const root_dir = process.cwd()
+  const first_attempt = tryLoadingMultiple(module_names)
+  const missing_modules = module_names.filter((name) => first_attempt[name].error)
+
+  if (missing_modules.length === 0) {
+    return module_names.map((name) => first_attempt[name].module)
+  }
+
+  const use_yarn = await useYarn(root_dir)
+  log(`❤️WARNING❤️: Missing required modules:
+  ${missing_modules.map((name) => `💛${name}💛`).join('\n')}`)
+  const proceed = await log.confirmAndRespond(
+    `Would you like to install them using 💛${use_yarn ? 'yarn' : 'npm'}💛?`
+  )
+  if (!proceed) {
+    log.error(`Cannot continue without these modules`)
+    throw first_attempt[missing_modules[0]].error
+  }
+  await installDependencies(use_yarn, missing_modules, root_dir)
+
+  const second_attempt = tryLoadingMultiple(missing_modules)
+  const still_missing = missing_modules.filter((name) => second_attempt[name].error)
+  if (still_missing.length > 0) {
+    log.error(`Still cannot resolve these modules: ${still_missing.join(',')}`)
+    throw second_attempt[still_missing[0]].error
+  }
+
+  return module_names.map(
+    (name) => second_attempt[name].module || first_attempt[name].module
+  )
+}
+
+export async function installDependencies(
+  use_yarn: boolean,
+  dependencies: string[],
+  root_dir: string
+) {
+  if (use_yarn) {
+    await execa('yarn', ['add', '--dev', ...dependencies], { cwd: root_dir })
+  } else {
+    await execa('npm', ['i', '--save-dev', ...dependencies], { cwd: root_dir })
+  }
+}

--- a/packages/deployer-aws-lambda/src/aws.ts
+++ b/packages/deployer-aws-lambda/src/aws.ts
@@ -11,7 +11,7 @@ export const updateLambda = async (
 ) => {
   log(`Updating Lambda`)
   const package_contents = await fs.readFile(package_path)
-  log(`💚✔💚 Read lambda package. Uploading...`)
+  log.tick(`Read lambda package. Uploading...`)
   const lambda = new aws.Lambda({
     accessKeyId,
     secretAccessKey,
@@ -91,7 +91,7 @@ export const updateCloudFront = async (
     update_response.Distribution?.DomainName,
     ...(config.DistributionConfig?.Aliases?.Items || []),
   ]
-  log(`💚✔💚 Done.`)
+  log.tick(`Done.`)
   log(`Got response status: 💛${update_response.Distribution?.Status}💛
     🖤(CloudFront can take a few minutes to update)🖤`)
   // todo: make this a config option
@@ -122,7 +122,7 @@ export const updateCloudFront = async (
       })
       .promise()
 
-    log(`💚✔💚 Done.`)
+    log.tick(`Done.`)
   } catch (e) {
     log(`❌ Invalidation failed. Could be a permissions issue?`)
   }

--- a/packages/deployer-aws-lambda/src/createPackage.ts
+++ b/packages/deployer-aws-lambda/src/createPackage.ts
@@ -16,11 +16,11 @@ export const createPackage: FabPackager<ConfigTypes.AwsLambda> = async (
   const output_dir = path.dirname(package_path)
   const work_dir = path.join(output_dir, `aws-lambda-${nanoid()}`)
   await fs.ensureDir(work_dir)
-  log(`💚✔💚 Generated working dir in 💛${work_dir}💛`)
+  log.tick(`Generated working dir in 💛${work_dir}💛`)
   await extract(fab_path, work_dir)
-  log(`💚✔💚 Unpacked FAB`)
+  log.tick(`Unpacked FAB`)
   await fs.copy(path.join(__dirname, '../templates'), work_dir)
-  log(`💚✔💚 Copied AWS Lambda shim`)
+  log.tick(`Copied AWS Lambda shim`)
 
   const parsed = new URL(assets_url)
   const packaged_config = {
@@ -34,7 +34,7 @@ export const createPackage: FabPackager<ConfigTypes.AwsLambda> = async (
     path.join(work_dir, 'packaged_config.js'),
     `module.exports = ${JSON.stringify(packaged_config)};`
   )
-  log(`💚✔💚 Generated PACKAGED_CONFIG file`)
+  log.tick(`Generated PACKAGED_CONFIG file`)
 
   // await copyIndex(work_dir)
   const packaged = new Zip()
@@ -43,6 +43,6 @@ export const createPackage: FabPackager<ConfigTypes.AwsLambda> = async (
   packaged.addFile(path.join(work_dir, 'server.js'), 'server.js')
   packaged.addFolder(path.join(work_dir, 'vendor'), 'vendor')
   await packaged.archive(package_path)
-  log(`💚✔💚 Generated lambda zip file`)
+  log.tick(`Generated lambda zip file`)
   log.time((d) => `Created package in ${d}.`)
 }

--- a/packages/deployer-aws-s3/src/index.ts
+++ b/packages/deployer-aws-s3/src/index.ts
@@ -18,9 +18,9 @@ export const deployAssets: FabAssetsDeployer<ConfigTypes.AwsS3> = async (
 
   const extracted_dir = path.join(working_dir, `cf-workers-${nanoid()}`)
   await fs.ensureDir(extracted_dir)
-  log(`💚✔💚 Generated working dir in 💛${extracted_dir}💛.`)
+  log.tick(`Generated working dir in 💛${extracted_dir}💛.`)
   await extract(fab_path, extracted_dir)
-  log(`💚✔💚 Unpacked FAB.`)
+  log.tick(`Unpacked FAB.`)
 
   return await doUpload(access_key, secret_key, region, bucket_name, extracted_dir)
 }
@@ -36,10 +36,10 @@ const doUpload = async (
 
   const s3 = authenticate(region, access_key, secret_key)
   await createBucket(s3, bucket_name)
-  log(`💚✔💚 Created bucket 💛${bucket_name}💛 in region 💛${region}💛.`)
+  log.tick(`Created bucket 💛${bucket_name}💛 in region 💛${region}💛.`)
 
   await makeBucketWebsite(s3, bucket_name)
-  log(`💚✔💚 Configured S3 website at 💛${assets_host}💛.`)
+  log.tick(`Configured S3 website at 💛${assets_host}💛.`)
 
   log(`Uploading files...`)
   const files = await globby(['_assets/**/*'], { cwd: extracted_dir })

--- a/packages/deployer-cf-workers/src/createPackage.ts
+++ b/packages/deployer-cf-workers/src/createPackage.ts
@@ -24,9 +24,9 @@ export const createPackage: FabPackager<ConfigTypes.CFWorkers> = async (
   const output_dir = path.dirname(package_path)
   const work_dir = path.join(output_dir, `cf-workers-${nanoid()}`)
   await fs.ensureDir(work_dir)
-  log(`💚✔💚 Generated working dir in 💛${work_dir}💛.`)
+  log.tick(`Generated working dir in 💛${work_dir}💛.`)
   await extract(fab_path, work_dir)
-  log(`💚✔💚 Unpacked FAB.`)
+  log.tick(`Unpacked FAB.`)
 
   const fab_server_src = await fs.readFile(path.join(work_dir, 'server.js'), 'utf8')
   const injections = templateInjections(fab_server_src, assets_url)
@@ -39,7 +39,7 @@ export const createPackage: FabPackager<ConfigTypes.CFWorkers> = async (
     ${injections};
     ${template};
   `
-  log(`💚✔💚 Generated worker file.`)
+  log.tick(`Generated worker file.`)
 
   const worker_file = path.join(work_dir, 'worker.js')
   await fs.writeFile(worker_file, worker_js)

--- a/packages/deployer-cf-workers/src/deploy.ts
+++ b/packages/deployer-cf-workers/src/deploy.ts
@@ -104,7 +104,7 @@ export const deployServer: FabServerDeployer<ConfigTypes.CFWorkers> = async (
       ❤️${JSON.stringify(create_route_response)}❤️`)
       }
     }
-    log(`💚✔💚 Done.`)
+    log.tick(`Done.`)
     log.time((d) => `Deployed in ${d}.`)
 
     return new URL(route).origin
@@ -140,7 +140,7 @@ export const deployServer: FabServerDeployer<ConfigTypes.CFWorkers> = async (
       throw new FabDeployError(`Error publishing the script on a workers.dev subdomain, got response:
       ❤️${JSON.stringify(publish_response)}❤️`)
     }
-    log(`💚✔💚 Done.`)
+    log.tick(`Done.`)
     log.time((d) => `Deployed in ${d}.`)
 
     return `https://${script_name}.${subdomain}.workers.dev`
@@ -182,7 +182,7 @@ function checkValidityForZoneRoutes(config: ConfigTypes.CFWorkers) {
 }
 
 async function getApi(api_token: string) {
-  log(`💚✔💚 Config valid, checking API token...`)
+  log.tick(`Config valid, checking API token...`)
   const api = await getCloudflareApi(api_token)
   return api
 }
@@ -197,7 +197,7 @@ async function packageAndUpload(
   account_id: string,
   script_name: string
 ) {
-  log(`💚✔💚 API token valid, packaging...`)
+  log.tick(`API token valid, packaging...`)
   await createPackage(fab_path, package_path, config, env_overrides, assets_url)
 
   log.time(`Uploading script...`)
@@ -211,5 +211,5 @@ async function packageAndUpload(
     throw new FabDeployError(`Error uploading the script, got response:
     ❤️${JSON.stringify(upload_response)}❤️`)
   }
-  log(`💚✔💚 Uploaded, publishing...`)
+  log.tick(`Uploaded, publishing...`)
 }

--- a/packages/input-nextjs/src/build.ts
+++ b/packages/input-nextjs/src/build.ts
@@ -40,7 +40,7 @@ export const build: FabBuildStep<InputNextJSArgs, InputNextJSMetadata> = async (
   const pages_dir_hash = await md5dir(pages_dir)
   // console.log({ pages_dir, pages_dir_hash })
 
-  log(`Finding all static HTML pages`)
+  log(`Finding all static HTML pages...`)
   const html_files = await globby([`**/*.html`, `!_*`], { cwd: pages_dir })
 
   await Promise.all(
@@ -52,7 +52,7 @@ export const build: FabBuildStep<InputNextJSArgs, InputNextJSMetadata> = async (
     })
   )
 
-  log(`Found 💛${html_files.length} static html pages💛.`)
+  log.tick(`Found 💛${html_files.length} static html pages💛.`)
 
   const cache_dir = path.join(config_dir, '.fab', '.cache')
   const render_code_file = path.join(
@@ -146,9 +146,9 @@ export const build: FabBuildStep<InputNextJSArgs, InputNextJSMetadata> = async (
         `/_next/static/${asset_file}`,
         await fs.readFile(path.resolve(static_dir, asset_file))
       )
-      log(`  💛${asset_file}💛 read.`)
     }
   }
+  log.tick(`Found ${asset_files.length} assets.`)
 
   log(`Finding all public files`)
   const public_files = await globby([`**/*`], { cwd: public_dir })
@@ -158,7 +158,7 @@ export const build: FabBuildStep<InputNextJSArgs, InputNextJSMetadata> = async (
         `/${public_file}`,
         await fs.readFile(path.resolve(public_dir, public_file))
       )
-      log(`  💛${public_file}💛 read.`)
+      log.tick(`🖤${public_file}🖤`, 2)
     }
   }
 }
@@ -192,6 +192,6 @@ async function getRenderCode(
     previous_caches.map((cache) => fs.remove(path.join(cache_dir, cache)))
   )
   await fs.writeFile(renderer_cache, render_code)
-  log(`💚✔💚 Wrote 💛${renderer_cache}💛`)
+  log.tick(`Wrote 💛${renderer_cache}💛`)
   return render_code
 }

--- a/packages/input-nextjs/src/runtime.ts
+++ b/packages/input-nextjs/src/runtime.ts
@@ -72,11 +72,11 @@ export function runtime() {
 
   return async function responder({ request, url }) {
     //   global.FAB_SETTINGS = settings
-    console.log(`REQUEST! ${url}`)
+    // console.log(`REQUEST! ${url}`)
     const { pathname, protocol } = url
 
     const renderer = pathname === '/' ? getRenderer('/index') : getRenderer(pathname)
-    console.log({ renderer })
+    // console.log({ renderer })
     if (renderer) {
       return await invokeRenderer(renderer, request, pathname, protocol)
     }

--- a/packages/plugin-render-html/src/build.ts
+++ b/packages/plugin-render-html/src/build.ts
@@ -40,7 +40,7 @@ export async function build(args: ServeHtmlArgs, proto_fab: ProtoFab<ServeHtmlMe
       // console.log(filename)
       // console.log(htmls[filename].strings.map(str => str.slice(0, 100)))
       // console.log(htmls[filename].varNames)
-      log(`💚  ✔💚 🖤${filename}🖤`)
+      log.tick(`🖤${filename}🖤`, 2)
       // await new Promise((res) => setTimeout(res, 200))
     }
   }

--- a/packages/plugin-rewire-assets/src/build.ts
+++ b/packages/plugin-rewire-assets/src/build.ts
@@ -58,7 +58,7 @@ export async function build(
     proto_fab.files.delete(filename)
   }
 
-  log(`💚✔💚 Done.`)
+  log.tick(`Done.`)
   log(
     `Generating server code to rewire 💛${to_rename.length}💛 asset${
       to_rename.length === 1 ? '' : 's'
@@ -82,6 +82,7 @@ export async function build(
     proto_fab.files.set(asset_path, contents)
     proto_fab.files.delete(filename)
   }
+  log.tick(`Done.`)
 
   proto_fab.metadata.rewire_assets = { inlined_assets, renamed_assets }
 }

--- a/packages/plugin-rewire-assets/src/runtime.ts
+++ b/packages/plugin-rewire-assets/src/runtime.ts
@@ -27,7 +27,6 @@ export const runtime: FabPluginRuntime<RewireAssetsArgs, RewireAssetsMetadata> =
     const renamed = matchPath(renamed_assets, pathname)
     if (renamed) {
       if (renamed.immutable) {
-        console.log('Returning new request!!')
         return new Request(renamed.asset_path)
       } else {
         const response = await fetch(renamed.asset_path)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,6 +3411,11 @@ dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -7737,6 +7742,13 @@ resolve@^1.11.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Didn't like how much code I was shipping with `npx fab init`, cause previously I didn't want `fab serve` to just explode without having installed `@fab/server`. Setting this up to load this on demand, and also do the same with deploy config. Should be good!