### PR TITLE
Auto install flag

### DIFF
--- a/.github/workflows/public-consumer.yml
+++ b/.github/workflows/public-consumer.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - next
       - master
+      - auto-install-flag
 
 jobs:
   public_package_build:

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.1.5"
+  "version": "0.1.6-alpha.0"
 }

--- a/packages/_fab/README.md
+++ b/packages/_fab/README.md
@@ -31,7 +31,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.1.4 darwin-x64 node-v13.12.0
+@fab/cli/0.1.5 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -69,7 +69,7 @@ EXAMPLES
   $ fab build --config=fab.config.json5
 ```
 
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/build.js)_
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/build.js)_
 
 ## `fab deploy [FILE]`
 
@@ -91,6 +91,9 @@ OPTIONS
 
   --assets-only                                            Skip server deploy, just upload assets
 
+  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
+                                                           them without prompting
+
   --env=env                                                Override production settings with a different environment
                                                            defined in your FAB config file.
 
@@ -103,7 +106,7 @@ EXAMPLE
   $ fab deploy fab.zip
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -143,7 +146,7 @@ EXAMPLES
   $ fab init --config=fab.config.json5
 ```
 
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/init.js)_
 
 ## `fab package [FILE]`
 
@@ -172,7 +175,7 @@ EXAMPLE
   $ fab package --target=aws-lambda-edge fab.zip
 ```
 
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/package.js)_
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/package.js)_
 
 ## `fab serve [FILE]`
 
@@ -187,6 +190,8 @@ OPTIONS
                              --env.
 
   -h, --help                 show CLI help
+
+  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
 
   --cert=cert                SSL certificate to use
 
@@ -205,6 +210,6 @@ EXAMPLES
   $ fab serve --env=staging fab.zip
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/_fab/README.md
+++ b/packages/_fab/README.md
@@ -31,7 +31,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.1.5 darwin-x64 node-v13.12.0
+@fab/cli/0.1.6-alpha.0 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -69,7 +69,7 @@ EXAMPLES
   $ fab build --config=fab.config.json5
 ```
 
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/build.js)_
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/build.js)_
 
 ## `fab deploy [FILE]`
 
@@ -106,7 +106,7 @@ EXAMPLE
   $ fab deploy fab.zip
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -146,7 +146,7 @@ EXAMPLES
   $ fab init --config=fab.config.json5
 ```
 
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/init.js)_
 
 ## `fab package [FILE]`
 
@@ -175,7 +175,7 @@ EXAMPLE
   $ fab package --target=aws-lambda-edge fab.zip
 ```
 
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/package.js)_
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/package.js)_
 
 ## `fab serve [FILE]`
 
@@ -210,6 +210,6 @@ EXAMPLES
   $ fab serve --env=staging fab.zip
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/_fab/package.json
+++ b/packages/_fab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fab",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "An alias for @fab/cli",
   "keywords": [
     "fab"
@@ -27,6 +27,6 @@
     "prepack": "cat PREAMBLE.md > README.md && cat ../cli/README.md >> README.md"
   },
   "dependencies": {
-    "@fab/cli": "0.1.4"
+    "@fab/cli": "0.1.5"
   }
 }

--- a/packages/_fab/package.json
+++ b/packages/_fab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fab",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "An alias for @fab/cli",
   "keywords": [
     "fab"
@@ -27,6 +27,6 @@
     "prepack": "cat PREAMBLE.md > README.md && cat ../cli/README.md >> README.md"
   },
   "dependencies": {
-    "@fab/cli": "0.1.5"
+    "@fab/cli": "0.1.6-alpha.0"
   }
 }

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/actions",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "private": false,
   "description": "The guts of the FAB cli code, keeping the 'fab' package lean",
   "keywords": [
@@ -31,8 +31,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-inject": "^4.0.1",

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/actions",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "The guts of the FAB cli code, keeping the 'fab' package lean",
   "keywords": [
@@ -31,8 +31,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-inject": "^4.0.1",

--- a/packages/actions/src/Deployer.ts
+++ b/packages/actions/src/Deployer.ts
@@ -19,6 +19,8 @@ import {
 const log = _log('Deployer')
 
 export default class Deployer {
+  private static auto_install: boolean
+
   static async deploy(
     config: JSON5Config,
     file_path: string,
@@ -27,8 +29,11 @@ export default class Deployer {
     assets_host: DeployProviders | undefined,
     env: string | undefined,
     assets_only: boolean,
-    assets_already_deployed_at: string | undefined
+    assets_already_deployed_at: string | undefined,
+    auto_install: boolean
   ) {
+    this.auto_install = auto_install
+
     log(`💎 💚fab deployer💚 💎\n`)
     const { deploy } = config.data
 
@@ -137,7 +142,7 @@ export default class Deployer {
 
   private static async loadPackage<T>(provider: string, fn: string): Promise<T> {
     const pkg = HOSTING_PROVIDERS[provider].package_name
-    const loaded = await loadOrInstallModule(log, pkg)
+    const loaded = await loadOrInstallModule(log, pkg, this.auto_install)
 
     if (typeof loaded[fn] !== 'function') {
       throw new FabDeployError(`${pkg} doesn't export a '${fn}' method!`)
@@ -154,7 +159,11 @@ export default class Deployer {
   ): Promise<[T, U]> {
     const pkgA = HOSTING_PROVIDERS[providerA].package_name
     const pkgB = HOSTING_PROVIDERS[providerB].package_name
-    const [loadedA, loadedB] = await loadOrInstallModules(log, [pkgA, pkgB])
+    const [loadedA, loadedB] = await loadOrInstallModules(
+      log,
+      [pkgA, pkgB],
+      this.auto_install
+    )
 
     if (typeof loadedA[fnA] !== 'function') {
       throw new FabDeployError(`${pkgA} doesn't export a '${fnA}' method!`)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.1.4 darwin-x64 node-v13.12.0
+@fab/cli/0.1.5 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -34,66 +34,7 @@ USAGE
 
 <!-- commands -->
 
-- [`fab build`](#fab-build)
-- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
-- [`fab init`](#fab-init)
-- [`fab package [FILE]`](#fab-package-file)
-- [`fab serve [FILE]`](#fab-serve-file)
-
-## `fab build`
-
-Generate a FAB given the config (usually in fab.config.json5)
-
-```
-USAGE
-  $ fab build
-
-OPTIONS
-  -c, --config=config  [default: fab.config.json5] Path to config file
-  -h, --help           show CLI help
-  --skip-cache         Skip any caching of intermediate build artifacts
-
-EXAMPLES
-  $ fab build
-  $ fab build --config=fab.config.json5
-```
-
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/build.js)_
-
-## `fab deploy [FILE]`
-
-Deploy a FAB to a hosting provider
-
-```
-USAGE
-  $ fab deploy [FILE]
-
-OPTIONS
-  -c, --config=config                                      [default: fab.config.json5] Path to config file
-  -h, --help                                               show CLI help
-
-  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
-                                                           pointing at this URL for assets
-
-  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-  --assets-only                                            Skip server deploy, just upload assets
-
-  --env=env                                                Override production settings with a different environment
-                                                           defined in your FAB config file.
-
-  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
-
-  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-EXAMPLE
-  $ fab deploy fab.zip
-```
-
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -111,90 +52,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
-
-## `fab init`
-
-Auto-configure a repo for generating FABs
-
-```
-USAGE
-  $ fab init
-
-OPTIONS
-  -c, --config=config         [default: fab.config.json5] Config filename
-  -h, --help                  show CLI help
-  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
-  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
-  --skip-install              Do not attempt to npm install anything
-  --version=version           What NPM version or dist-tag to use for installing FAB packages
-
-EXAMPLES
-  $ fab init
-  $ fab init --config=fab.config.json5
-```
-
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/init.js)_
-
-## `fab package [FILE]`
-
-Package a FAB to be uploaded to a hosting provider manually
-
-```
-USAGE
-  $ fab package [FILE]
-
-OPTIONS
-  -c, --config=config                               [default: fab.config.json5] Path to config file
-  -h, --help                                        show CLI help
-
-  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
-                                                    aws-s3)
-
-  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
-                                                    that need it
-
-  --env=env                                         Override production settings with a different environment defined in
-                                                    your FAB config file.
-
-  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
-
-EXAMPLE
-  $ fab package --target=aws-lambda-edge fab.zip
-```
-
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/package.js)_
-
-## `fab serve [FILE]`
-
-fab serve: Serve a FAB in a local NodeJS Express server
-
-```
-USAGE
-  $ fab serve [FILE]
-
-OPTIONS
-  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
-                             --env.
-
-  -h, --help                 show CLI help
-
-  --cert=cert                SSL certificate to use
-
-  --env=env                  Override production settings with a different environment defined in your FAB config file.
-
-  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
-
-  --key=key                  Key for the SSL Certificate
-
-  --port=port                (required) [default: 3000] Port to use
-
-EXAMPLES
-  $ fab serve fab.zip
-  $ fab serve --port=3001 fab.zip
-  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
-  $ fab serve --env=staging fab.zip
-```
-
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.4/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,69 @@ USAGE
 
 <!-- commands -->
 
+- [`fab build`](#fab-build)
+- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
+- [`fab init`](#fab-init)
+- [`fab package [FILE]`](#fab-package-file)
+- [`fab serve [FILE]`](#fab-serve-file)
+
+## `fab build`
+
+Generate a FAB given the config (usually in fab.config.json5)
+
+```
+USAGE
+  $ fab build
+
+OPTIONS
+  -c, --config=config  [default: fab.config.json5] Path to config file
+  -h, --help           show CLI help
+  --skip-cache         Skip any caching of intermediate build artifacts
+
+EXAMPLES
+  $ fab build
+  $ fab build --config=fab.config.json5
+```
+
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/build.js)_
+
+## `fab deploy [FILE]`
+
+Deploy a FAB to a hosting provider
+
+```
+USAGE
+  $ fab deploy [FILE]
+
+OPTIONS
+  -c, --config=config                                      [default: fab.config.json5] Path to config file
+  -h, --help                                               show CLI help
+
+  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
+                                                           pointing at this URL for assets
+
+  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+  --assets-only                                            Skip server deploy, just upload assets
+
+  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
+                                                           them without prompting
+
+  --env=env                                                Override production settings with a different environment
+                                                           defined in your FAB config file.
+
+  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
+
+  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+EXAMPLE
+  $ fab deploy fab.zip
+```
+
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -52,5 +114,92 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+
+## `fab init`
+
+Auto-configure a repo for generating FABs
+
+```
+USAGE
+  $ fab init
+
+OPTIONS
+  -c, --config=config         [default: fab.config.json5] Config filename
+  -h, --help                  show CLI help
+  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
+  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
+  --skip-install              Do not attempt to npm install anything
+  --version=version           What NPM version or dist-tag to use for installing FAB packages
+
+EXAMPLES
+  $ fab init
+  $ fab init --config=fab.config.json5
+```
+
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/init.js)_
+
+## `fab package [FILE]`
+
+Package a FAB to be uploaded to a hosting provider manually
+
+```
+USAGE
+  $ fab package [FILE]
+
+OPTIONS
+  -c, --config=config                               [default: fab.config.json5] Path to config file
+  -h, --help                                        show CLI help
+
+  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
+                                                    aws-s3)
+
+  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
+                                                    that need it
+
+  --env=env                                         Override production settings with a different environment defined in
+                                                    your FAB config file.
+
+  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
+
+EXAMPLE
+  $ fab package --target=aws-lambda-edge fab.zip
+```
+
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/package.js)_
+
+## `fab serve [FILE]`
+
+fab serve: Serve a FAB in a local NodeJS Express server
+
+```
+USAGE
+  $ fab serve [FILE]
+
+OPTIONS
+  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
+                             --env.
+
+  -h, --help                 show CLI help
+
+  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
+
+  --cert=cert                SSL certificate to use
+
+  --env=env                  Override production settings with a different environment defined in your FAB config file.
+
+  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
+
+  --key=key                  Key for the SSL Certificate
+
+  --port=port                (required) [default: 3000] Port to use
+
+EXAMPLES
+  $ fab serve fab.zip
+  $ fab serve --port=3001 fab.zip
+  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
+  $ fab serve --env=staging fab.zip
+```
+
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.6-alpha.0/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,69 @@ USAGE
 
 <!-- commands -->
 
+- [`fab build`](#fab-build)
+- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
+- [`fab init`](#fab-init)
+- [`fab package [FILE]`](#fab-package-file)
+- [`fab serve [FILE]`](#fab-serve-file)
+
+## `fab build`
+
+Generate a FAB given the config (usually in fab.config.json5)
+
+```
+USAGE
+  $ fab build
+
+OPTIONS
+  -c, --config=config  [default: fab.config.json5] Path to config file
+  -h, --help           show CLI help
+  --skip-cache         Skip any caching of intermediate build artifacts
+
+EXAMPLES
+  $ fab build
+  $ fab build --config=fab.config.json5
+```
+
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/build.js)_
+
+## `fab deploy [FILE]`
+
+Deploy a FAB to a hosting provider
+
+```
+USAGE
+  $ fab deploy [FILE]
+
+OPTIONS
+  -c, --config=config                                      [default: fab.config.json5] Path to config file
+  -h, --help                                               show CLI help
+
+  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
+                                                           pointing at this URL for assets
+
+  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+  --assets-only                                            Skip server deploy, just upload assets
+
+  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
+                                                           them without prompting
+
+  --env=env                                                Override production settings with a different environment
+                                                           defined in your FAB config file.
+
+  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
+
+  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+EXAMPLE
+  $ fab deploy fab.zip
+```
+
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -52,5 +114,92 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+
+## `fab init`
+
+Auto-configure a repo for generating FABs
+
+```
+USAGE
+  $ fab init
+
+OPTIONS
+  -c, --config=config         [default: fab.config.json5] Config filename
+  -h, --help                  show CLI help
+  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
+  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
+  --skip-install              Do not attempt to npm install anything
+  --version=version           What NPM version or dist-tag to use for installing FAB packages
+
+EXAMPLES
+  $ fab init
+  $ fab init --config=fab.config.json5
+```
+
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/init.js)_
+
+## `fab package [FILE]`
+
+Package a FAB to be uploaded to a hosting provider manually
+
+```
+USAGE
+  $ fab package [FILE]
+
+OPTIONS
+  -c, --config=config                               [default: fab.config.json5] Path to config file
+  -h, --help                                        show CLI help
+
+  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
+                                                    aws-s3)
+
+  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
+                                                    that need it
+
+  --env=env                                         Override production settings with a different environment defined in
+                                                    your FAB config file.
+
+  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
+
+EXAMPLE
+  $ fab package --target=aws-lambda-edge fab.zip
+```
+
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/package.js)_
+
+## `fab serve [FILE]`
+
+fab serve: Serve a FAB in a local NodeJS Express server
+
+```
+USAGE
+  $ fab serve [FILE]
+
+OPTIONS
+  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
+                             --env.
+
+  -h, --help                 show CLI help
+
+  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
+
+  --cert=cert                SSL certificate to use
+
+  --env=env                  Override production settings with a different environment defined in your FAB config file.
+
+  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
+
+  --key=key                  Key for the SSL Certificate
+
+  --port=port                (required) [default: 3000] Port to use
+
+EXAMPLES
+  $ fab serve fab.zip
+  $ fab serve --port=3001 fab.zip
+  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
+  $ fab serve --env=staging fab.zip
+```
+
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/0.1.5 darwin-x64 node-v13.12.0
+@fab/cli/0.1.6-alpha.0 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -34,69 +34,7 @@ USAGE
 
 <!-- commands -->
 
-- [`fab build`](#fab-build)
-- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
-- [`fab init`](#fab-init)
-- [`fab package [FILE]`](#fab-package-file)
-- [`fab serve [FILE]`](#fab-serve-file)
-
-## `fab build`
-
-Generate a FAB given the config (usually in fab.config.json5)
-
-```
-USAGE
-  $ fab build
-
-OPTIONS
-  -c, --config=config  [default: fab.config.json5] Path to config file
-  -h, --help           show CLI help
-  --skip-cache         Skip any caching of intermediate build artifacts
-
-EXAMPLES
-  $ fab build
-  $ fab build --config=fab.config.json5
-```
-
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/build.js)_
-
-## `fab deploy [FILE]`
-
-Deploy a FAB to a hosting provider
-
-```
-USAGE
-  $ fab deploy [FILE]
-
-OPTIONS
-  -c, --config=config                                      [default: fab.config.json5] Path to config file
-  -h, --help                                               show CLI help
-
-  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
-                                                           pointing at this URL for assets
-
-  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-  --assets-only                                            Skip server deploy, just upload assets
-
-  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
-                                                           them without prompting
-
-  --env=env                                                Override production settings with a different environment
-                                                           defined in your FAB config file.
-
-  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
-
-  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-EXAMPLE
-  $ fab deploy fab.zip
-```
-
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -114,92 +52,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
-
-## `fab init`
-
-Auto-configure a repo for generating FABs
-
-```
-USAGE
-  $ fab init
-
-OPTIONS
-  -c, --config=config         [default: fab.config.json5] Config filename
-  -h, --help                  show CLI help
-  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
-  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
-  --skip-install              Do not attempt to npm install anything
-  --version=version           What NPM version or dist-tag to use for installing FAB packages
-
-EXAMPLES
-  $ fab init
-  $ fab init --config=fab.config.json5
-```
-
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/init.js)_
-
-## `fab package [FILE]`
-
-Package a FAB to be uploaded to a hosting provider manually
-
-```
-USAGE
-  $ fab package [FILE]
-
-OPTIONS
-  -c, --config=config                               [default: fab.config.json5] Path to config file
-  -h, --help                                        show CLI help
-
-  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
-                                                    aws-s3)
-
-  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
-                                                    that need it
-
-  --env=env                                         Override production settings with a different environment defined in
-                                                    your FAB config file.
-
-  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
-
-EXAMPLE
-  $ fab package --target=aws-lambda-edge fab.zip
-```
-
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/package.js)_
-
-## `fab serve [FILE]`
-
-fab serve: Serve a FAB in a local NodeJS Express server
-
-```
-USAGE
-  $ fab serve [FILE]
-
-OPTIONS
-  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
-                             --env.
-
-  -h, --help                 show CLI help
-
-  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
-
-  --cert=cert                SSL certificate to use
-
-  --env=env                  Override production settings with a different environment defined in your FAB config file.
-
-  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
-
-  --key=key                  Key for the SSL Certificate
-
-  --port=port                (required) [default: 3000] Port to use
-
-EXAMPLES
-  $ fab serve fab.zip
-  $ fab serve --port=3001 fab.zip
-  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
-  $ fab serve --env=staging fab.zip
-```
-
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v0.1.5/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",
@@ -35,7 +35,7 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@fab/core": "0.1.5",
+    "@fab/core": "0.1.6-alpha.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",
@@ -35,7 +35,7 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@fab/core": "0.1.4",
+    "@fab/core": "0.1.5",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/cli/src/Initializer/constants.ts
+++ b/packages/cli/src/Initializer/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_DEPS = ['@fab/cli', '@fab/actions']
+export const DEFAULT_DEPS = ['@fab/cli', '@fab/server', '@fab/actions']
 export const DEPRECATED_PACKAGES = [
   '@fab/static',
   '@fab/compile',

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -43,6 +43,10 @@ export default class Deploy extends Command {
     'assets-only': flags.boolean({
       description: 'Skip server deploy, just upload assets',
     }),
+    'auto-install': flags.boolean({
+      description:
+        'If you need dependent packages (e.g. @fab/deploy-*), install them without prompting',
+    }),
   }
 
   static args = [{ name: 'file' }]
@@ -64,7 +68,8 @@ export default class Deploy extends Command {
       flags['assets-host'],
       flags.env,
       flags['assets-only'],
-      flags['assets-already-deployed-at']
+      flags['assets-already-deployed-at'],
+      flags['auto-install']
     )
   }
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -46,6 +46,10 @@ export default class Serve extends Command {
         'Path to config file. Only used for SETTINGS in conjunction with --env.',
       default: DEFAULT_CONFIG_FILENAME,
     }),
+    'auto-install': flags.boolean({
+      description:
+        'If you need dependent packages (e.g. @fab/serve), install them without prompting',
+    }),
   }
 
   static args = [{ name: 'file' }]
@@ -59,8 +63,9 @@ export default class Serve extends Command {
       this._help()
     }
     log.announce(`fab serve`)
-    const server_pkg = (await loadOrInstallModule(log, '@fab/server'))
-      .default as FabServerExports
+    const server_pkg = (
+      await loadOrInstallModule(log, '@fab/server', flags['auto-install'])
+    ).default as FabServerExports
     const server = server_pkg.createServer(file, flags as ServerArgs)
     await server.serve(
       flags['experimental-v8-sandbox'] ? SandboxType.v8isolate : SandboxType.nodeVm

--- a/packages/cli/src/helpers/modules.ts
+++ b/packages/cli/src/helpers/modules.ts
@@ -38,7 +38,8 @@ async function tryLoadingMultiple(module_names: string[]) {
 
 export async function loadOrInstallModules(
   log: Logger,
-  module_names: string[]
+  module_names: string[],
+  auto_install: boolean
 ): Promise<any[]> {
   const root_dir = process.cwd()
   const first_attempt = await tryLoadingMultiple(module_names)
@@ -51,9 +52,15 @@ export async function loadOrInstallModules(
   const use_yarn = await useYarn(root_dir)
   log(`❤️WARNING❤️: Missing required modules:
   ${missing_modules.map((name) => `💛${name}💛`).join('\n')}`)
-  const proceed = await log.confirmAndRespond(
-    `Would you like to install them using 💛${use_yarn ? 'yarn' : 'npm'}💛?`
-  )
+  const proceed = auto_install
+    ? log(
+        `NOTE: 💛--auto-install💛 set. Installing them using 💛${
+          use_yarn ? 'yarn' : 'npm'
+        }💛?`
+      )
+    : await log.confirmAndRespond(
+        `Would you like to install them using 💛${use_yarn ? 'yarn' : 'npm'}💛?`
+      )
   if (!proceed) {
     log.error(`Cannot continue without these modules`)
     throw first_attempt[missing_modules[0]].error
@@ -71,11 +78,13 @@ export async function loadOrInstallModules(
     (name) => second_attempt[name].module || first_attempt[name].module
   )
 }
+
 export async function loadOrInstallModule(
   log: Logger,
-  module_name: string
+  module_name: string,
+  auto_install: boolean
 ): Promise<any> {
-  return (await loadOrInstallModules(log, [module_name]))[0]
+  return (await loadOrInstallModules(log, [module_name], auto_install))[0]
 }
 
 export async function installDependencies(

--- a/packages/cli/src/helpers/modules.ts
+++ b/packages/cli/src/helpers/modules.ts
@@ -50,14 +50,14 @@ export async function loadOrInstallModules(
   }
 
   const use_yarn = await useYarn(root_dir)
-  log(`❤️WARNING❤️: Missing required modules:
+  log(`${
+    auto_install
+      ? `💚NOTE💚: Installing required modules due to 💛--auto-install💛 flag:`
+      : `❤️WARNING❤️: Missing required modules:`
+  }
   ${missing_modules.map((name) => `💛${name}💛`).join('\n')}`)
   const proceed = auto_install
-    ? log(
-        `NOTE: 💛--auto-install💛 set. Installing them using 💛${
-          use_yarn ? 'yarn' : 'npm'
-        }💛?`
-      )
+    ? log(`using 💛${use_yarn ? 'yarn' : 'npm'}💛.`)
     : await log.confirmAndRespond(
         `Would you like to install them using 💛${use_yarn ? 'yarn' : 'npm'}💛?`
       )

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "description": "Common code for all FAB projects",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/core",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "private": false,
   "description": "Common code for all FAB projects",
   "keywords": [

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,7 +197,8 @@ export type DeployFn = (
   assets_host: DeployProviders | undefined,
   env: string | undefined,
   assets_only: boolean,
-  assets_already_deployed_at: string | undefined
+  assets_already_deployed_at: string | undefined,
+  auto_install: boolean
 ) => Promise<string>
 
 export type BuildFn = (

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-lambda",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "aws",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.14",
     "deterministic-zip": "^1.1.0",

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-lambda",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "aws",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.14",
     "deterministic-zip": "^1.1.0",

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-s3",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Uploads FAB assets to AWS S3",
   "keywords": [
     "aws",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/node": "^12.12.14",
     "aws-sdk": "^2.655.0",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-s3",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Uploads FAB assets to AWS S3",
   "keywords": [
     "aws",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/node": "^12.12.14",
     "aws-sdk": "^2.655.0",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-cf-workers",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "cloudflare",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/node": "^12.12.14",
     "cross-fetch": "^3.0.4",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-cf-workers",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "cloudflare",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/node": "^12.12.14",
     "cross-fetch": "^3.0.4",
     "fs-extra": "^9.0.0",

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "aws",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/node": "^12.12.14",
     "@types/path-to-regexp": "^1.7.0",
     "acorn": "^7.1.0",

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "aws",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/node": "^12.12.14",
     "@types/path-to-regexp": "^1.7.0",
     "acorn": "^7.1.0",

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-static",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Module to handle a directory of HTML & assets",
   "keywords": [
     "fab",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/node": "^12.12.14",
     "fs-extra": "^8.1.0",
     "globby": "^10"

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-static",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Module to handle a directory of HTML & assets",
   "keywords": [
     "fab",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/node": "^12.12.14",
     "fs-extra": "^8.1.0",
     "globby": "^10"

--- a/packages/plugin-render-html/package.json
+++ b/packages/plugin-render-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-render-html",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Module to render static HTML files with FAB injections",
   "keywords": [
     "fab"
@@ -30,8 +30,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/cheerio": "^0.22.15",
     "@types/node": "^12.12.14",
     "cheerio": "^1.0.0-rc.3",

--- a/packages/plugin-render-html/package.json
+++ b/packages/plugin-render-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-render-html",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Module to render static HTML files with FAB injections",
   "keywords": [
     "fab"
@@ -30,8 +30,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/cheerio": "^0.22.15",
     "@types/node": "^12.12.14",
     "cheerio": "^1.0.0-rc.3",

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-rewire-assets",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "assets",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
     "@types/istextorbinary": "^2.3.0",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12.12.14",

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-rewire-assets",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "assets",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
     "@types/istextorbinary": "^2.3.0",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12.12.14",

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/sandbox-node-vm",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "FAB runtime sandbox using Node's 'vm'",
   "keywords": [
     "fab",
@@ -29,7 +29,7 @@
     "prepack": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@fab/core": "0.1.5",
+    "@fab/core": "0.1.6-alpha.0",
     "cross-fetch": "^3.0.4"
   },
   "publishConfig": {

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/sandbox-node-vm",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "FAB runtime sandbox using Node's 'vm'",
   "keywords": [
     "fab",
@@ -29,7 +29,7 @@
     "prepack": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@fab/core": "0.1.4",
+    "@fab/core": "0.1.5",
     "cross-fetch": "^3.0.4"
   },
   "publishConfig": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/server",
-  "version": "0.1.5",
+  "version": "0.1.6-alpha.0",
   "description": "NodeJS FAB Server",
   "keywords": [
     "fab",
@@ -30,9 +30,9 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.5",
-    "@fab/core": "0.1.5",
-    "@fab/sandbox-node-vm": "0.1.5",
+    "@fab/cli": "0.1.6-alpha.0",
+    "@fab/core": "0.1.6-alpha.0",
+    "@fab/sandbox-node-vm": "0.1.6-alpha.0",
     "@fly/v8env": "^0.54.0",
     "@types/concat-stream": "^1.6.0",
     "@types/express": "^4.17.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "NodeJS FAB Server",
   "keywords": [
     "fab",
@@ -30,9 +30,9 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "0.1.4",
-    "@fab/core": "0.1.4",
-    "@fab/sandbox-node-vm": "0.1.4",
+    "@fab/cli": "0.1.5",
+    "@fab/core": "0.1.5",
+    "@fab/sandbox-node-vm": "0.1.5",
     "@fly/v8env": "^0.54.0",
     "@types/concat-stream": "^1.6.0",
     "@types/express": "^4.17.2",

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -88,7 +88,10 @@ describe('Create React App E2E Test', () => {
     const createServer = async (port: number, args: string = '') => {
       cancelServer()
 
-      server_process = cmd(`yarn fab:serve --port=${port} ${args}`, { cwd })
+      const auto_install = process.env.PUBLIC_PACKAGES ? '--auto-install' : ''
+      server_process = cmd(`yarn fab:serve ${auto_install} --port=${port} ${args}`, {
+        cwd,
+      })
       // See if `server_process` explodes in the first 2 seconds (e.g. if the port is in use)
       await Promise.race([
         server_process,

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -63,6 +63,8 @@ describe('Create React App E2E Test', () => {
       'fab:serve': 'fab serve fab.zip',
     }
     await fs.writeFile(`${cwd}/package.json`, JSON.stringify(package_json, null, 2))
+    // Todo: this really shouldn't be needed.
+    await shell(`yarn add @fab/server`)
     await shell(`yarn build:fab`, { cwd })
 
     const { stdout: files_after_fab_build } = await cmd(`ls -l ${cwd}`)

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -63,8 +63,6 @@ describe('Create React App E2E Test', () => {
       'fab:serve': 'fab serve fab.zip',
     }
     await fs.writeFile(`${cwd}/package.json`, JSON.stringify(package_json, null, 2))
-    // Todo: this really shouldn't be needed.
-    await shell(`yarn add @fab/server`)
     await shell(`yarn build:fab`, { cwd })
 
     const { stdout: files_after_fab_build } = await cmd(`ls -l ${cwd}`)

--- a/tests/e2e/nextjs.test.ts
+++ b/tests/e2e/nextjs.test.ts
@@ -95,7 +95,10 @@ describe('Create React App E2E Test', () => {
       }
       await buildFab(cwd)
 
-      server_process = cmd(`yarn fab:serve --port=${port}`, { cwd })
+      const auto_install = process.env.PUBLIC_PACKAGES ? '--auto-install' : ''
+      server_process = cmd(`yarn fab:serve ${auto_install} --port=${port}`, {
+        cwd,
+      })
       // See if `server_process` explodes in the first 1 second (e.g. if the port is in use)
       await Promise.race([
         server_process,


### PR DESCRIPTION
For CI, prompting the user to approve installing the required plugins is no good, so let's skip it (but still actually use that code to install it, rather than installing it ourselves)