### PR TITLE
Streaming HTTP responses

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.0.0-rc.2.alpha.0"
+  "version": "1.0.0-rc.2.alpha.1"
 }

--- a/packages/_fab/README.md
+++ b/packages/_fab/README.md
@@ -31,7 +31,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/1.0.0-rc.2.alpha.0 darwin-x64 node-v13.12.0
+@fab/cli/1.0.0-rc.2.alpha.1 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -69,7 +69,7 @@ EXAMPLES
   $ fab build --config=fab.config.json5
 ```
 
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/build.js)_
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/build.js)_
 
 ## `fab deploy [FILE]`
 
@@ -106,7 +106,7 @@ EXAMPLE
   $ fab deploy fab.zip
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -146,7 +146,7 @@ EXAMPLES
   $ fab init --config=fab.config.json5
 ```
 
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/init.js)_
 
 ## `fab package [FILE]`
 
@@ -175,7 +175,7 @@ EXAMPLE
   $ fab package --target=aws-lambda-edge fab.zip
 ```
 
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/package.js)_
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/package.js)_
 
 ## `fab serve [FILE]`
 
@@ -210,6 +210,6 @@ EXAMPLES
   $ fab serve --env=staging fab.zip
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/_fab/package.json
+++ b/packages/_fab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fab",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "An alias for @fab/cli",
   "keywords": [
     "fab"
@@ -27,6 +27,6 @@
     "prepack": "cat PREAMBLE.md > README.md && cat ../cli/README.md >> README.md"
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0"
+    "@fab/cli": "1.0.0-rc.2.alpha.1"
   }
 }

--- a/packages/_fab/package.json
+++ b/packages/_fab/package.json
@@ -29,5 +29,5 @@
   "dependencies": {
     "@fab/cli": "1.0.0-rc.2.alpha.1"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/_fab/package.json
+++ b/packages/_fab/package.json
@@ -28,5 +28,6 @@
   },
   "dependencies": {
     "@fab/cli": "1.0.0-rc.2.alpha.1"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/actions",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "private": false,
   "description": "The guts of the FAB cli code, keeping the 'fab' package lean",
   "keywords": [
@@ -31,8 +31,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-inject": "^4.0.1",

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -55,5 +55,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a"
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/actions/src/runtime/index.ts
+++ b/packages/actions/src/runtime/index.ts
@@ -55,8 +55,8 @@ export const render: FabSpecRender = async (request: Request, settings: FabSetti
 
   let chained_request = request
 
-  for (const responders of Runtime.getPipeline()) {
-    const response = await responders({
+  for (const responder of Runtime.getPipeline()) {
+    const response = await responder({
       request: chained_request.clone(),
       settings,
       url,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/1.0.0-rc.2.alpha.0 darwin-x64 node-v13.12.0
+@fab/cli/1.0.0-rc.2.alpha.1 darwin-x64 node-v13.12.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -34,69 +34,7 @@ USAGE
 
 <!-- commands -->
 
-- [`fab build`](#fab-build)
-- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
-- [`fab init`](#fab-init)
-- [`fab package [FILE]`](#fab-package-file)
-- [`fab serve [FILE]`](#fab-serve-file)
-
-## `fab build`
-
-Generate a FAB given the config (usually in fab.config.json5)
-
-```
-USAGE
-  $ fab build
-
-OPTIONS
-  -c, --config=config  [default: fab.config.json5] Path to config file
-  -h, --help           show CLI help
-  --skip-cache         Skip any caching of intermediate build artifacts
-
-EXAMPLES
-  $ fab build
-  $ fab build --config=fab.config.json5
-```
-
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/build.js)_
-
-## `fab deploy [FILE]`
-
-Deploy a FAB to a hosting provider
-
-```
-USAGE
-  $ fab deploy [FILE]
-
-OPTIONS
-  -c, --config=config                                      [default: fab.config.json5] Path to config file
-  -h, --help                                               show CLI help
-
-  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
-                                                           pointing at this URL for assets
-
-  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-  --assets-only                                            Skip server deploy, just upload assets
-
-  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
-                                                           them without prompting
-
-  --env=env                                                Override production settings with a different environment
-                                                           defined in your FAB config file.
-
-  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
-
-  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
-                                                           in your fab.config.json5, which one to deploy to.
-
-EXAMPLE
-  $ fab deploy fab.zip
-```
-
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -114,92 +52,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
-
-## `fab init`
-
-Auto-configure a repo for generating FABs
-
-```
-USAGE
-  $ fab init
-
-OPTIONS
-  -c, --config=config         [default: fab.config.json5] Config filename
-  -h, --help                  show CLI help
-  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
-  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
-  --skip-install              Do not attempt to npm install anything
-  --version=version           What NPM version or dist-tag to use for installing FAB packages
-
-EXAMPLES
-  $ fab init
-  $ fab init --config=fab.config.json5
-```
-
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/init.js)_
-
-## `fab package [FILE]`
-
-Package a FAB to be uploaded to a hosting provider manually
-
-```
-USAGE
-  $ fab package [FILE]
-
-OPTIONS
-  -c, --config=config                               [default: fab.config.json5] Path to config file
-  -h, --help                                        show CLI help
-
-  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
-                                                    aws-s3)
-
-  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
-                                                    that need it
-
-  --env=env                                         Override production settings with a different environment defined in
-                                                    your FAB config file.
-
-  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
-
-EXAMPLE
-  $ fab package --target=aws-lambda-edge fab.zip
-```
-
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/package.js)_
-
-## `fab serve [FILE]`
-
-fab serve: Serve a FAB in a local NodeJS Express server
-
-```
-USAGE
-  $ fab serve [FILE]
-
-OPTIONS
-  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
-                             --env.
-
-  -h, --help                 show CLI help
-
-  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
-
-  --cert=cert                SSL certificate to use
-
-  --env=env                  Override production settings with a different environment defined in your FAB config file.
-
-  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
-
-  --key=key                  Key for the SSL Certificate
-
-  --port=port                (required) [default: 3000] Port to use
-
-EXAMPLES
-  $ fab serve fab.zip
-  $ fab serve --port=3001 fab.zip
-  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
-  $ fab serve --env=staging fab.zip
-```
-
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.0/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -34,7 +34,69 @@ USAGE
 
 <!-- commands -->
 
+- [`fab build`](#fab-build)
+- [`fab deploy [FILE]`](#fab-deploy-file)
 - [`fab help [COMMAND]`](#fab-help-command)
+- [`fab init`](#fab-init)
+- [`fab package [FILE]`](#fab-package-file)
+- [`fab serve [FILE]`](#fab-serve-file)
+
+## `fab build`
+
+Generate a FAB given the config (usually in fab.config.json5)
+
+```
+USAGE
+  $ fab build
+
+OPTIONS
+  -c, --config=config  [default: fab.config.json5] Path to config file
+  -h, --help           show CLI help
+  --skip-cache         Skip any caching of intermediate build artifacts
+
+EXAMPLES
+  $ fab build
+  $ fab build --config=fab.config.json5
+```
+
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/build.js)_
+
+## `fab deploy [FILE]`
+
+Deploy a FAB to a hosting provider
+
+```
+USAGE
+  $ fab deploy [FILE]
+
+OPTIONS
+  -c, --config=config                                      [default: fab.config.json5] Path to config file
+  -h, --help                                               show CLI help
+
+  --assets-already-deployed-at=assets-already-deployed-at  Skip asset deploys and only deploy the server component
+                                                           pointing at this URL for assets
+
+  --assets-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the assets defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+  --assets-only                                            Skip server deploy, just upload assets
+
+  --auto-install                                           If you need dependent packages (e.g. @fab/deploy-*), install
+                                                           them without prompting
+
+  --env=env                                                Override production settings with a different environment
+                                                           defined in your FAB config file.
+
+  --package-dir=package-dir                                Where to save the packaged FAB files (default .fab/deploy)
+
+  --server-host=(cf-workers|aws-lambda-edge|aws-s3)        If you have multiple potential hosts for the server defined
+                                                           in your fab.config.json5, which one to deploy to.
+
+EXAMPLE
+  $ fab deploy fab.zip
+```
+
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -52,5 +114,92 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
+
+## `fab init`
+
+Auto-configure a repo for generating FABs
+
+```
+USAGE
+  $ fab init
+
+OPTIONS
+  -c, --config=config         [default: fab.config.json5] Config filename
+  -h, --help                  show CLI help
+  -y, --yes                   Assume yes to all prompts (must be in the root directory of a project)
+  --skip-framework-detection  Don't try to auto-detect framework, set up manually.
+  --skip-install              Do not attempt to npm install anything
+  --version=version           What NPM version or dist-tag to use for installing FAB packages
+
+EXAMPLES
+  $ fab init
+  $ fab init --config=fab.config.json5
+```
+
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/init.js)_
+
+## `fab package [FILE]`
+
+Package a FAB to be uploaded to a hosting provider manually
+
+```
+USAGE
+  $ fab package [FILE]
+
+OPTIONS
+  -c, --config=config                               [default: fab.config.json5] Path to config file
+  -h, --help                                        show CLI help
+
+  -t, --target=(cf-workers|aws-lambda-edge|aws-s3)  Hosting provider (must be one of: cf-workers, aws-lambda-edge,
+                                                    aws-s3)
+
+  --assets-url=assets-url                           A URL for where the assets can be accessed, for server deployers
+                                                    that need it
+
+  --env=env                                         Override production settings with a different environment defined in
+                                                    your FAB config file.
+
+  --output-path=output-path                         Where to save the packaged FAB (default .fab/deploy/[target].zip)
+
+EXAMPLE
+  $ fab package --target=aws-lambda-edge fab.zip
+```
+
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/package.js)_
+
+## `fab serve [FILE]`
+
+fab serve: Serve a FAB in a local NodeJS Express server
+
+```
+USAGE
+  $ fab serve [FILE]
+
+OPTIONS
+  -c, --config=config        [default: fab.config.json5] Path to config file. Only used for SETTINGS in conjunction with
+                             --env.
+
+  -h, --help                 show CLI help
+
+  --auto-install             If you need dependent packages (e.g. @fab/serve), install them without prompting
+
+  --cert=cert                SSL certificate to use
+
+  --env=env                  Override production settings with a different environment defined in your FAB config file.
+
+  --experimental-v8-sandbox  Enable experimental V8::Isolate Runtime (in development, currently non-functional)
+
+  --key=key                  Key for the SSL Certificate
+
+  --port=port                (required) [default: 3000] Port to use
+
+EXAMPLES
+  $ fab serve fab.zip
+  $ fab serve --port=3001 fab.zip
+  $ fab serve --cert=local-ssl.cert --key=local-ssl.key fab.zip
+  $ fab serve --env=staging fab.zip
+```
+
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.2.alpha.1/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",
@@ -35,7 +35,7 @@
     "version": "oclif-dev readme && git add README.md"
   },
   "dependencies": {
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/errors": "^1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a",
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65",
   "oclif": {
     "commands": "./lib/commands",
     "bin": "fab",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,5 +35,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a"
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/core",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "private": false,
   "description": "Common code for all FAB projects",
   "keywords": [

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -32,8 +32,9 @@ export function getCacheHeaders(immutable: boolean) {
 
 export function matchPath<T>(
   lookup_table: { [pathname: string]: T },
-  pathname: string
+  _pathname: string
 ): T | undefined {
+  const pathname = decodeURIComponent(_pathname)
   return (
     lookup_table[pathname] ||
     lookup_table[pathname + '.html'] ||

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-lambda",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "aws",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.14",
     "deterministic-zip": "^1.1.0",

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -44,5 +44,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/deployer-aws-lambda/package.json
+++ b/packages/deployer-aws-lambda/package.json
@@ -45,5 +45,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-aws-s3",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Uploads FAB assets to AWS S3",
   "keywords": [
     "aws",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/node": "^12.12.14",
     "aws-sdk": "^2.655.0",
     "fs-extra": "^9.0.0",

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -44,5 +44,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/deployer-aws-s3/package.json
+++ b/packages/deployer-aws-s3/package.json
@@ -45,5 +45,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -44,5 +44,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/deployer-cf-workers",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Packages and deploys FABs to AWS Lambda@Edge",
   "keywords": [
     "cloudflare",
@@ -33,8 +33,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/node": "^12.12.14",
     "cross-fetch": "^3.0.4",
     "file-to-sha512": "^0.0.1",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -45,5 +45,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/deployer-cf-workers/templates/index.js
+++ b/packages/deployer-cf-workers/templates/index.js
@@ -5,24 +5,21 @@ const server_context = globalThis.__server_context // inlined in packager
 
 const mutableResponse = (response) => new Response(response.body, response)
 
-class ReadableStream {
-  constructor({ start, cancel }) {
-    const { readable, writable } = new TransformStream()
-    console.log(readable)
-    this.readable = readable
-    this.writer = writable.getWriter()
-    this.encoder = new TextEncoder()
+function ReadableStream({ start, cancel }) {
+  const { readable, writable } = new TransformStream()
+  const writer = writable.getWriter()
+  const encoder = new TextEncoder()
 
-    start(this)
-  }
+  start({
+    enqueue(chunk) {
+      writer.write(encoder.encode(chunk))
+    },
+    close() {
+      writer.close()
+    },
+  })
 
-  enqueue(chunk) {
-    this.writer.write(this.encoder.encode(chunk))
-  }
-
-  close() {
-    this.writer.close()
-  }
+  return readable
 }
 
 globalThis.orig_fetch = globalThis.fetch
@@ -44,18 +41,6 @@ globalThis.fetch = (request, init) => {
 if (typeof FAB.initialize === 'function') FAB.initialize(server_context)
 
 const handleRequest = async (request, within_loop = false) => {
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        controller.enqueue('hello there glenby\n')
-        setTimeout(() => {
-          controller.enqueue('me slow!!')
-          controller.close()
-        }, 1000)
-      },
-    }).readable
-  )
-
   console.log({ request })
   console.log(request.url)
   const url = new URL(request.url)

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -51,5 +51,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "aws",
@@ -34,8 +34,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/node": "^12.12.14",
     "@types/path-to-regexp": "^1.7.0",
     "acorn": "^7.1.0",

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-static",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Module to handle a directory of HTML & assets",
   "keywords": [
     "fab",
@@ -31,8 +31,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/node": "^12.12.14",
     "fs-extra": "^8.1.0",
     "globby": "^10"

--- a/packages/input-static/package.json
+++ b/packages/input-static/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a"
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/plugin-render-html/package.json
+++ b/packages/plugin-render-html/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/plugin-render-html/package.json
+++ b/packages/plugin-render-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-render-html",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Module to render static HTML files with FAB injections",
   "keywords": [
     "fab"
@@ -30,8 +30,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/cheerio": "^0.22.15",
     "@types/node": "^12.12.14",
     "cheerio": "^1.0.0-rc.3",

--- a/packages/plugin-render-html/package.json
+++ b/packages/plugin-render-html/package.json
@@ -40,5 +40,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a"
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -43,5 +43,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -43,5 +43,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "98ce34423f906c0a9f66f2f87643e64b841e359a"
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-rewire-assets",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "assets",
@@ -32,8 +32,8 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "@types/istextorbinary": "^2.3.0",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^12.12.14",

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@fab/core": "1.0.0-rc.2.alpha.0",
-    "cross-fetch": "^3.0.4",
-    "web-streams-node": "^0.4.0"
+    "node-fetch": "^2.6.0",
+    "web-streams-ponyfill": "^1.4.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@fab/core": "1.0.0-rc.2.alpha.0",
-    "cross-fetch": "^3.0.4"
+    "cross-fetch": "^3.0.4",
+    "web-streams-node": "^0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/sandbox-node-vm",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "FAB runtime sandbox using Node's 'vm'",
   "keywords": [
     "fab",
@@ -29,7 +29,7 @@
     "prepack": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@fab/core": "1.0.0-rc.2.alpha.0",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
     "node-fetch": "^2.6.0",
     "web-streams-ponyfill": "^1.4.2"
   },

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -35,5 +35,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/sandbox-node-vm/src/index.ts
+++ b/packages/sandbox-node-vm/src/index.ts
@@ -1,6 +1,8 @@
 import vm from 'vm'
 import * as fetch from 'cross-fetch'
 import { FabSpecExports, FetchApi } from '@fab/core'
+// @ts-ignore
+import { ReadableStream } from 'web-streams-ponyfill'
 
 export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports> => {
   const sandbox = {
@@ -9,6 +11,7 @@ export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports>
     Response: fetch.Response,
     Headers: fetch.Headers,
     URL: URL,
+    ReadableStream,
     console: {
       log: console.log,
       error: console.error,

--- a/packages/sandbox-node-vm/src/index.ts
+++ b/packages/sandbox-node-vm/src/index.ts
@@ -1,8 +1,31 @@
 import vm from 'vm'
-import * as fetch from 'cross-fetch'
-import { FabSpecExports, FetchApi } from '@fab/core'
+import * as fetch from 'node-fetch'
+import { FabSpecExports } from '@fab/core'
 // @ts-ignore
 import { ReadableStream } from 'web-streams-ponyfill'
+import Stream from 'stream'
+
+/*
+ * We're using node-fetch under the hood, which has a hard-coded check on the body:
+ *   response.body instanceof Stream
+ * this means that our Web Streams ReadableStream gets .toString()-ed, which breaks.
+ * This lets FAB users use ReadableStream as if it was on the web, but this Node VM
+ * (which will be replaced by the V8::Isolate-based VM) can trick node-fetch into
+ * doing what we want. See https://github.com/node-fetch/node-fetch/pull/848
+ *
+ * */
+function HybridReadableStream(...args: any[]) {
+  const readableStream = new ReadableStream(...args)
+  return new Proxy(readableStream, {
+    getPrototypeOf() {
+      return Stream.Readable.prototype
+    },
+    get(target, prop, receiver) {
+      if (prop === 'on') return () => {}
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
 
 export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports> => {
   const sandbox = {
@@ -11,7 +34,7 @@ export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports>
     Response: fetch.Response,
     Headers: fetch.Headers,
     URL: URL,
-    ReadableStream,
+    ReadableStream: HybridReadableStream,
     console: {
       log: console.log,
       error: console.error,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -49,5 +49,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
+  "gitHead": "289f6ed3041d9b76850ebf5f205aeaacf9c5c52a"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,6 +38,7 @@
     "@types/express": "^4.17.2",
     "@types/node": "^12.12.14",
     "@types/yauzl": "^2.9.1",
+    "concat-stream": "^2.0.0",
     "cross-fetch": "^3.0.4",
     "express": "^4.17.1",
     "file-to-sha512": "^0.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/server",
-  "version": "1.0.0-rc.2.alpha.0",
+  "version": "1.0.0-rc.2.alpha.1",
   "description": "NodeJS FAB Server",
   "keywords": [
     "fab",
@@ -30,9 +30,9 @@
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\""
   },
   "dependencies": {
-    "@fab/cli": "1.0.0-rc.2.alpha.0",
-    "@fab/core": "1.0.0-rc.2.alpha.0",
-    "@fab/sandbox-node-vm": "1.0.0-rc.2.alpha.0",
+    "@fab/cli": "1.0.0-rc.2.alpha.1",
+    "@fab/core": "1.0.0-rc.2.alpha.1",
+    "@fab/sandbox-node-vm": "1.0.0-rc.2.alpha.1",
     "@fly/v8env": "^0.54.0",
     "@types/concat-stream": "^1.6.0",
     "@types/express": "^4.17.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -48,5 +48,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "7993c1665c36c74ab0e8b4bcf0efb43c80490f65"
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,10 +67,7 @@ class Server implements ServerType {
     const enhanced_fetch: FetchApi = async (url, init?) => {
       const request_url = typeof url === 'string' ? url : url.url
       if (request_url.startsWith('/')) {
-        if (!request_url.startsWith('/_assets/')) {
-          throw new Error('Fetching relative URLs for non-assets is not permitted.')
-        }
-        // Need a smarter wau to fetch assets, of course, but for now...
+        // Need a smarter wau to re-enter the FAB, eventually...
         return fetch(`http://localhost:${this.port}${request_url}`, init)
       }
 

--- a/tests/e2e/fixtures/server-side-logic/fab-plugins/slowly.ts
+++ b/tests/e2e/fixtures/server-side-logic/fab-plugins/slowly.ts
@@ -1,0 +1,24 @@
+import { FABRuntime } from '@fab/core'
+
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))
+
+export default ({ Router }: FABRuntime) => {
+  Router.on('/slowly', async () => {
+    const stream = new ReadableStream({
+      async start(controller) {
+        controller.enqueue('Des\n')
+        await sleep(500)
+        controller.enqueue('pa\n')
+        await sleep(500)
+        controller.enqueue('cito.\n')
+        controller.close()
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    })
+  })
+}

--- a/tests/e2e/fixtures/server-side-logic/fab.config.json5
+++ b/tests/e2e/fixtures/server-side-logic/fab.config.json5
@@ -5,6 +5,7 @@
     '@fab/plugin-rewire-assets': {},
     './fab-plugins/hello-world': {},
     './fab-plugins/add-bundle-id': {},
+    './fab-plugins/slowly': {},
   },
   settings: { production: {} },
   deploy: {},

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -90,5 +90,30 @@ describe('Server-side logic tests', () => {
       expect(hello_fab_response).not.toEqual(homepage_response)
       expect(hello_fab_response).toContain('HELLO FAB!')
     })
+
+    it('should hit a streaming endpoint', async () => {
+      const promise = cwd_shell(`curl -sN http://localhost:${port}/slowly`)
+
+      const lines_with_timestamps: { [line: string]: Date } = {}
+      promise.stdout!.on('data', (data) => {
+        data
+          .toString()
+          .split('\n')
+          .forEach((line: string) => {
+            lines_with_timestamps[line.trim()] = new Date()
+          })
+      })
+
+      await promise
+
+      const des_time = lines_with_timestamps['Des'].getTime()
+      const pa_time = lines_with_timestamps['pa'].getTime()
+      const cito_time = lines_with_timestamps['cito.'].getTime()
+
+      expect(pa_time - des_time).toBeGreaterThan(100)
+      expect(pa_time - des_time).toBeLessThan(900)
+      expect(cito_time - pa_time).toBeGreaterThan(100)
+      expect(cito_time - pa_time).toBeLessThan(900)
+    })
   })
 })

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@types/jest": "^24.0.23",
+    "concurrently": "^5.2.0",
     "dotenv": "^8.2.0",
     "file-to-sha512": "^0.0.1",
     "globby": "^11.0.0",

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -5,14 +5,14 @@ export const cmd = (command: string, ...opts: any) => {
   return execa.command(command, ...opts)
 }
 
-export const shell = async (command: string, ...opts: any) => {
+export const shell = (command: string, ...opts: any) => {
   if (opts.cwd) process.stdout.write(`[${opts.cwd}] `)
   const promise = cmd(command, ...opts)
   promise.stdout!.pipe(process.stdout)
   promise.stderr!.pipe(process.stderr)
   return promise
 }
-export const _shell = (cwd: string) => async (command: string, ...opts: any) =>
+export const _shell = (cwd: string) => (command: string, ...opts: any) =>
   shell(command, { cwd, ...opts })
 
 const SHOULD_HAVE_THROWN = `Shouldn't get here, expected to have already thrown`

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -816,6 +816,21 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+concurrently@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.2.0.tgz#ead55121d08a0fc817085584c123cedec2e08975"
+  integrity sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==
+  dependencies:
+    chalk "^2.4.2"
+    date-fns "^2.0.1"
+    lodash "^4.17.15"
+    read-pkg "^4.0.1"
+    rxjs "^6.5.2"
+    spawn-command "^0.0.2-1"
+    supports-color "^6.1.0"
+    tree-kill "^1.2.2"
+    yargs "^13.3.0"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -897,6 +912,11 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-fns@^2.0.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -2385,11 +2405,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-md5-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-4.0.0.tgz#f3f7ba1e2dd1144d5bf1de698d0e5f44a4409584"
-  integrity sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg==
-
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -2996,6 +3011,15 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 readable-stream@^2.0.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -3146,6 +3170,13 @@ run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
+
+rxjs@^6.5.2:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"
@@ -3326,6 +3357,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -3617,6 +3653,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 ts-jest@^24.1.0:
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.1.0.tgz#2eaa813271a2987b7e6c3fefbda196301c131734"
@@ -3637,6 +3678,11 @@ tslib@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^1.9.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6251,7 +6251,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -7356,11 +7356,6 @@ read@1, read@~1.0.1:
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
   dependencies:
     mute-stream "~0.0.4"
-
-readable-stream-node-to-web@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
-  integrity sha1-i3YU+qFGXr+g2pucpjA/onBzt88=
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
@@ -8909,16 +8904,7 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-node@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/web-streams-node/-/web-streams-node-0.4.0.tgz#641e42d7a7c4df95785a774e2484ba93d36fd672"
-  integrity sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==
-  dependencies:
-    is-stream "^1.1.0"
-    readable-stream-node-to-web "^1.0.1"
-    web-streams-ponyfill "^1.4.1"
-
-web-streams-ponyfill@^1.4.1:
+web-streams-ponyfill@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz#0ae863cc5f7493903679f16b08cbf14d432b62f4"
   integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7357,6 +7357,11 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
+readable-stream-node-to-web@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
+  integrity sha1-i3YU+qFGXr+g2pucpjA/onBzt88=
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
@@ -8903,6 +8908,20 @@ wcwidth@^1.0.0:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-node@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/web-streams-node/-/web-streams-node-0.4.0.tgz#641e42d7a7c4df95785a774e2484ba93d36fd672"
+  integrity sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==
+  dependencies:
+    is-stream "^1.1.0"
+    readable-stream-node-to-web "^1.0.1"
+    web-streams-ponyfill "^1.4.1"
+
+web-streams-ponyfill@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz#0ae863cc5f7493903679f16b08cbf14d432b62f4"
+  integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Why respond fast when you can respond... slowly:

```ts
import { FABRuntime } from '@fab/core'

const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms))

export default ({ Router }: FABRuntime) => {
  Router.on('/slowly', async () => {
    const stream = new ReadableStream({
      async start(controller) {
        controller.enqueue('Des\n')
        await sleep(500)
        controller.enqueue('pa\n')
        await sleep(500)
        controller.enqueue('cito.\n')
        controller.close()
      },
    })

    return new Response(stream, {
      headers: {
        'Content-Type': 'text/plain',
      },
    })
  })
}
```

Seriously though, streaming HTTP responses is a big part of the future of FABs and the web. Not all FAB hosts will support them (looking at you, AWS Lambda), and the above API is just a proof of concept, but useful enough to test E2E that streaming works! And it does!