### PR TITLE
Update test names in e2e tests

### DIFF
--- a/packages/input-nextjs/src/preflightChecks.ts
+++ b/packages/input-nextjs/src/preflightChecks.ts
@@ -29,8 +29,9 @@ export async function preflightChecks(
   if (next_config.target !== 'serverless') {
     throw new BuildFailedError(`Not serverless build
       NextJS project needs to be set to ${chalk.yellow('target: serverless')}
-      You'll need to update your ${chalk.yellow('next.config.js')} file.
-    `) // Add a documentation page for this info and link it here.
+      You'll need to update your ${chalk.yellow('next.config.js')} file. 
+      (https://fab.dev/guides/known-project-types#nextjs-9-dynamic-serverless)
+    `)
   }
 
   const notBuilt = (reason: string) => {

--- a/tests/e2e/nextjs.test.ts
+++ b/tests/e2e/nextjs.test.ts
@@ -6,10 +6,10 @@ import path from 'path'
 
 const getPort = getPorts(NEXTJS_PORTS)
 
-describe('Create React App E2E Test', () => {
+describe('Nextjs E2E Test', () => {
   let cwd: string
 
-  it('should create a new CRA project', async () => {
+  it('should create a new Next project', async () => {
     cwd = await getWorkingDir('nextjs-test', !process.env.FAB_E2E_SKIP_CREATE)
     const { stdout: current_sha } = await cmd(`git rev-parse --short HEAD`, { cwd })
     const { stdout: current_branch } = await cmd(`git rev-parse --abbrev-ref HEAD`, {
@@ -20,7 +20,7 @@ describe('Create React App E2E Test', () => {
       await shell(`git reset --hard`, { cwd })
       await shell(`git clean -df`, { cwd })
     } else {
-      // Create a new CRA project inside
+      // Create a new NEXT project inside
       await shell(`yarn create next-app . -e`, { cwd })
       // Skip git stuff on Github, it's only for rerunning locally
       if (!process.env.GITHUB_WORKSPACE) {


### PR DESCRIPTION
Noticed that some of the e2e tests said CRA but were for next also added a link to documentation in the error message of the preflight check