### PR TITLE
S3 endpoints

### DIFF
--- a/docs/fab.config.json5
+++ b/docs/fab.config.json5
@@ -2,11 +2,11 @@
 {
   plugins: {
     '@fab/input-static': {
-      dir: 'dist'
+      dir: 'dist',
     },
     './redirects.ts': {},
     '@fab/plugin-render-html': {},
-    '@fab/plugin-rewire-assets': {}
+    '@fab/plugin-rewire-assets': {},
     // This section defines your build & runtime toolchains. See https://fab.dev/kb/plugins
   },
   settings: {
@@ -17,22 +17,23 @@
       // allowing for many production-specific optimisations. See https://fab.dev/kb/production
       // Example setting:
       // API_URL: 'https://api.example.com/graphql'
-    }
+    },
   },
   deploy: {
-    "cf-workers": {
-      account_id: "@CF_WORKERS_ACCOUNT_ID",
-      api_token: "@CF_WORKERS_API_TOKEN",
+    'cf-workers': {
+      account_id: '@CF_WORKERS_ACCOUNT_ID',
+      api_token: '@CF_WORKERS_API_TOKEN',
       workers_dev: false,
-      script_name: "fab-dev-manual-deploy",
-      zone_id: "@FAB_DEV_ZONE_ID",
-      route: "https://next.fab.dev/*"
+      script_name: 'fab-dev-manual-deploy',
+      zone_id: '@FAB_DEV_ZONE_ID',
+      route: 'https://next.fab.dev/*',
     },
-//    "aws-s3": {
-//      access_key: "@S3_ACCESS_KEY",
-//      secret_key: "@S3_SECRET_KEY",
-//      region: "us-east-1",
-//      bucket_name: "fab-ci-assets-fab-dev-manual-deploy"
-//    }
-  }
+//    'aws-s3': {
+//      access_key: '@S3_ACCESS_KEY',
+//      secret_key: '@S3_SECRET_KEY',
+//      region: 'us-west-1',
+//      bucket_name: 'fab-ci-assets-fab-dev-manual-deploy-west',
+//      endpoint: 'https://s3.us-west-1.amazonaws.com',
+//    },
+  },
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "build:fab": "npm run build && npm run export && npm run fab:build",
     "fab:build": "fab build",
     "fab:serve": "fab serve fab.zip",
-    "fab:deploy": "fab deploy fab.zip",
+    "deploy": "fab deploy fab.zip",
     "start": "nuxt start",
     "export": "nuxt export",
     "serve": "nuxt serve"

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -30,6 +30,7 @@ const AWS_S3_CONFIG = {
   secret_key: '',
   region: '',
   bucket_name: '',
+  endpoint: ''
 }
 
 export namespace ConfigTypes {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -30,7 +30,7 @@ const AWS_S3_CONFIG = {
   secret_key: '',
   region: '',
   bucket_name: '',
-  endpoint: ''
+  endpoint: '',
 }
 
 export namespace ConfigTypes {

--- a/packages/deployer-aws-s3/src/aws.ts
+++ b/packages/deployer-aws-s3/src/aws.ts
@@ -2,13 +2,18 @@ import aws from 'aws-sdk'
 import { ReadStream } from 'fs'
 import { IMMUTABLE_HEADERS } from '@fab/core'
 
-export function authenticate(region: string, access_key: string, secret_key: string) {
+export function authenticate(
+  region: string,
+  access_key: string,
+  secret_key: string,
+  endpoint?: string
+) {
   aws.config.update({
     region,
     accessKeyId: access_key,
     secretAccessKey: secret_key,
   })
-  return new aws.S3()
+  return new aws.S3({ endpoint })
 }
 
 export async function createBucket(s3: aws.S3, bucket_name: string) {

--- a/packages/deployer-aws-s3/src/index.ts
+++ b/packages/deployer-aws-s3/src/index.ts
@@ -13,7 +13,7 @@ export const deployAssets: FabAssetsDeployer<ConfigTypes.AwsS3> = async (
   package_dir: string,
   config: ConfigTypes.AwsS3
 ) => {
-  const { bucket_name, access_key, secret_key, region = 'us-east-1' } = config
+  const { bucket_name, access_key, secret_key, region = 'us-east-1', endpoint } = config
   if (!bucket_name) throw new Error('Need to specify a bucket name!')
 
   const extracted_dir = path.join(package_dir, `aws-s3-${nanoid()}`)
@@ -22,7 +22,14 @@ export const deployAssets: FabAssetsDeployer<ConfigTypes.AwsS3> = async (
   await extract(fab_path, extracted_dir)
   log.tick(`Unpacked FAB.`)
 
-  return await doUpload(access_key, secret_key, region, bucket_name, extracted_dir)
+  return await doUpload(
+    access_key,
+    secret_key,
+    region,
+    bucket_name,
+    extracted_dir,
+    endpoint
+  )
 }
 
 const doUpload = async (
@@ -30,7 +37,8 @@ const doUpload = async (
   secret_key: string,
   region: string,
   bucket_name: string,
-  extracted_dir: string
+  extracted_dir: string,
+  endpoint?: string
 ) => {
   const assets_host = `https://${bucket_name}.s3.${region}.amazonaws.com`
 


### PR DESCRIPTION
Add `endpoint` as a config for S3 uploads. Allows deploying to different regions with:

```json5
    'aws-s3': {
      access_key: '@S3_ACCESS_KEY',
      secret_key: '@S3_SECRET_KEY',
      region: 'us-west-1',
      bucket_name: 'fab-ci-assets-fab-dev-manual-deploy-west',
      endpoint: 'https://s3.us-west-1.amazonaws.com',
    },
```

The `endpoint` isn't required here, region should do it, but this a) does work, and b) allows people to push static assets to any S3-compatible API like https://wasabi.com/