### PR TITLE
Watch mode

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@types/prettier": "^1.19.0",
     "@types/semver": "^6.2.0",
     "chalk": "^3.0.0",
+    "chokidar": "^3.4.0",
     "cli-ux": "^5.4.5",
     "dotenv": "^8.2.0",
     "execa": "^4.0.0",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -6,7 +6,11 @@ import { watcher } from '../helpers/watcher'
 export default class Build extends Command {
   static description = 'Generate a FAB given the config (usually in fab.config.json5)'
 
-  static examples = [`$ fab build`, `$ fab build --config=fab.config.json5`]
+  static examples = [
+    `$ fab build`,
+    `$ fab build --config=fab.config.json5`,
+    `$ fab build --watch dist --watch fab.config.json5`,
+  ]
 
   static flags = {
     help: flags.help({ char: 'h' }),
@@ -20,6 +24,8 @@ export default class Build extends Command {
     }),
     watch: flags.string({
       multiple: true,
+      description:
+        'Re-run the builder if any of the listed files change. Pass this argument multiple times to watch multiple files/directories.',
     }),
   }
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,7 @@
 import { Command, flags } from '@oclif/command'
 import { DEFAULT_CONFIG_FILENAME, FabActionsExports } from '@fab/core'
 import { JSON5Config } from '../'
+import chokidar from 'chokidar'
 
 export default class Build extends Command {
   static description = 'Generate a FAB given the config (usually in fab.config.json5)'
@@ -26,9 +27,34 @@ export default class Build extends Command {
 
   async run() {
     const { args, flags } = this.parse(Build)
-    console.log(flags.watch)
     const config = await JSON5Config.readFrom(flags.config!)
     const { Builder } = require('@fab/actions').default as FabActionsExports
-    // await Builder.build(flags.config, config.data, flags['skip-cache'])
+    const watch = flags.watch || []
+
+    const build = async () => {
+      await Builder.build(flags.config, config.data, flags['skip-cache'])
+    }
+
+    if (watch.length > 0) {
+      let building = false
+
+      const rebuild = async (message: string) => {
+        if (building) return
+        building = true
+        console.clear()
+        console.log(message)
+        await build()
+        building = false
+      }
+
+      rebuild(`Watching paths: ${watch.join(' ')}`)
+      chokidar.watch(watch).on('ready', () => {
+        chokidar.watch(watch).on('all', (event, path) => {
+          rebuild(`${path} changed`)
+        })
+      })
+    } else {
+      await build()
+    }
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -17,14 +17,18 @@ export default class Build extends Command {
     'skip-cache': flags.boolean({
       description: 'Skip any caching of intermediate build artifacts',
     }),
+    watch: flags.string({
+      multiple: true,
+    }),
   }
 
   static args = []
 
   async run() {
     const { args, flags } = this.parse(Build)
+    console.log(flags.watch)
     const config = await JSON5Config.readFrom(flags.config!)
     const { Builder } = require('@fab/actions').default as FabActionsExports
-    await Builder.build(flags.config, config.data, flags['skip-cache'])
+    // await Builder.build(flags.config, config.data, flags['skip-cache'])
   }
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -33,10 +33,10 @@ export default class Build extends Command {
 
   async run() {
     const { args, flags } = this.parse(Build)
-    const config = await JSON5Config.readFrom(flags.config!)
     const { Builder } = require('@fab/actions').default as FabActionsExports
 
     await watcher(flags.watch, async () => {
+      const config = await JSON5Config.readFrom(flags.config!)
       await Builder.build(flags.config, config.data, flags['skip-cache'])
     })
   }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from '@oclif/command'
 import { DEFAULT_CONFIG_FILENAME, FabActionsExports } from '@fab/core'
 import { JSON5Config } from '../'
-import chokidar from 'chokidar'
+import { watcher } from '../helpers/watcher'
 
 export default class Build extends Command {
   static description = 'Generate a FAB given the config (usually in fab.config.json5)'
@@ -29,32 +29,9 @@ export default class Build extends Command {
     const { args, flags } = this.parse(Build)
     const config = await JSON5Config.readFrom(flags.config!)
     const { Builder } = require('@fab/actions').default as FabActionsExports
-    const watch = flags.watch || []
 
-    const build = async () => {
+    await watcher(flags.watch, async () => {
       await Builder.build(flags.config, config.data, flags['skip-cache'])
-    }
-
-    if (watch.length > 0) {
-      let building = false
-
-      const rebuild = async (message: string) => {
-        if (building) return
-        building = true
-        console.clear()
-        console.log(message)
-        await build()
-        building = false
-      }
-
-      rebuild(`Watching paths: ${watch.join(' ')}`)
-      chokidar.watch(watch).on('ready', () => {
-        chokidar.watch(watch).on('all', (event, path) => {
-          rebuild(`${path} changed`)
-        })
-      })
-    } else {
-      await build()
-    }
+    })
   }
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -6,6 +6,7 @@ import {
   FabServerExports,
 } from '@fab/core'
 import { loadOrInstallModule, _log } from '../helpers'
+import fs from 'fs-extra'
 const log = _log(`Server`)
 
 export default class Serve extends Command {
@@ -57,10 +58,15 @@ export default class Serve extends Command {
   async run() {
     const { args, flags } = this.parse(Serve)
 
-    const { file } = args
+    let { file } = args
     if (!file) {
-      log.error('ERROR: You must provide a FAB filename to serve.\n')
-      this._help()
+      if (!(await fs.pathExists('fab.zip'))) {
+        log.error(
+          'ERROR: You must provide a FAB filename to serve, if fab.zip is not present in the current directory.\n'
+        )
+        this._help()
+      }
+      file = 'fab.zip'
     }
     log.announce(`fab serve`)
     const server_pkg = (

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -53,7 +53,7 @@ export default class Serve extends Command {
     }),
     watch: flags.boolean({
       description:
-        'EXPERIMENTAL: Watches all plugins referenced in fab.config.json5 and rebuilds the runtime component when any of them change.',
+        'EXPERIMENTAL: Watches fab.zip and restarts the server when it changes.',
     }),
   }
 
@@ -85,7 +85,8 @@ export default class Serve extends Command {
     ).default as FabServerExports
     const server = server_pkg.createServer(file, flags as ServerArgs)
     await server.serve(
-      flags['experimental-v8-sandbox'] ? SandboxType.v8isolate : SandboxType.nodeVm
+      flags['experimental-v8-sandbox'] ? SandboxType.v8isolate : SandboxType.nodeVm,
+      flags.watch
     )
   }
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -58,16 +58,23 @@ export default class Serve extends Command {
   async run() {
     const { args, flags } = this.parse(Serve)
 
-    let { file } = args
-    if (!file) {
-      if (!(await fs.pathExists('fab.zip'))) {
-        log.error(
-          'ERROR: You must provide a FAB filename to serve, if fab.zip is not present in the current directory.\n'
-        )
+    const { file: specified_file } = args
+    const default_file = 'fab.zip'
+
+    if (specified_file) {
+      if (!(await fs.pathExists(specified_file))) {
+        log.error(`ERROR: Cannot file find file '${specified_file}'.\n`)
         this._help()
       }
-      file = 'fab.zip'
+    } else if (!(await fs.pathExists(default_file))) {
+      log.error(
+        `ERROR: You must provide a FAB filename to serve, if '${default_file}' is not present in the current directory.\n`
+      )
+      this._help()
     }
+
+    const file = specified_file || default_file
+
     log.announce(`fab serve`)
     const server_pkg = (
       await loadOrInstallModule(log, '@fab/server', flags['auto-install'])

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -51,6 +51,10 @@ export default class Serve extends Command {
       description:
         'If you need dependent packages (e.g. @fab/serve), install them without prompting',
     }),
+    watch: flags.boolean({
+      description:
+        'EXPERIMENTAL: Watches all plugins referenced in fab.config.json5 and rebuilds the runtime component when any of them change.',
+    }),
   }
 
   static args = [{ name: 'file' }]

--- a/packages/cli/src/errors/index.ts
+++ b/packages/cli/src/errors/index.ts
@@ -8,3 +8,4 @@ import { createDescriptiveErrorClass } from './DescriptiveError'
 export const FabInitError = createDescriptiveErrorClass('Fab init failed!')
 export const FabDeployError = createDescriptiveErrorClass('Fab deploy failed!')
 export const FabPackageError = createDescriptiveErrorClass('Fab package failed!')
+export const FabServerError = createDescriptiveErrorClass('Fab serve failed!')

--- a/packages/cli/src/helpers/index.ts
+++ b/packages/cli/src/helpers/index.ts
@@ -4,6 +4,7 @@ import { IPromptOptions } from 'cli-ux/lib/prompt'
 
 export * from './paths'
 export * from './modules'
+export * from './watcher'
 
 export const confirmAndRespond = async (
   log: Logger,

--- a/packages/cli/src/helpers/watcher.ts
+++ b/packages/cli/src/helpers/watcher.ts
@@ -1,6 +1,10 @@
-import chokidar from 'chokidar'
+import chokidar, { WatchOptions } from 'chokidar'
 
-export const watcher = async (dirs: string[] | undefined, fn: () => Promise<void>) => {
+export const watcher = async (
+  dirs: string[] | undefined,
+  fn: () => Promise<void>,
+  options?: WatchOptions
+) => {
   if (dirs && dirs.length > 0) {
     let building = false
 
@@ -17,7 +21,7 @@ export const watcher = async (dirs: string[] | undefined, fn: () => Promise<void
     run_fn_once_at_a_time(`Watching paths: ${dirs.join(' ')}`)
 
     chokidar.watch(dirs).on('ready', () => {
-      chokidar.watch(dirs).on('all', (event, path) => {
+      chokidar.watch(dirs, options).on('all', (event, path) => {
         run_fn_once_at_a_time(`${path} changed`)
       })
     })

--- a/packages/cli/src/helpers/watcher.ts
+++ b/packages/cli/src/helpers/watcher.ts
@@ -1,0 +1,27 @@
+import chokidar from 'chokidar'
+
+export const watcher = async (dirs: string[] | undefined, fn: () => Promise<void>) => {
+  if (dirs && dirs.length > 0) {
+    let building = false
+
+    const run_fn_once_at_a_time = async (message: string) => {
+      if (building) return
+      building = true
+      console.clear()
+      console.log(message)
+      await fn()
+      building = false
+    }
+
+    // noinspection ES6MissingAwait
+    run_fn_once_at_a_time(`Watching paths: ${dirs.join(' ')}`)
+
+    chokidar.watch(dirs).on('ready', () => {
+      chokidar.watch(dirs).on('all', (event, path) => {
+        run_fn_once_at_a_time(`${path} changed`)
+      })
+    })
+  } else {
+    await fn()
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,7 +116,7 @@ export type FABServerContext = {
 
 export type ServerConstructor = (filename: string, args: ServerArgs) => ServerType
 export interface ServerType {
-  serve(runtimeType: SandboxType): Promise<void>
+  serve(runtimeType: SandboxType, watch: boolean): Promise<void>
 }
 export type ServerArgs = {
   port: string

--- a/packages/plugin-render-html/src/build.ts
+++ b/packages/plugin-render-html/src/build.ts
@@ -14,7 +14,7 @@ export async function build(
   const {
     'match-html': match_html = /\.html$/i,
     injections = DEFAULT_INJECTIONS,
-    fallback = true,
+    fallback,
   } = args
 
   const htmls: CompiledHTMLs = {}

--- a/packages/plugin-render-html/src/runtime.ts
+++ b/packages/plugin-render-html/src/runtime.ts
@@ -34,7 +34,7 @@ export default function RenderHTMLRuntime({
 
     return new Response(rendered, {
       status: html === error_page ? 404 : 200,
-      statusText: 'OK',
+      statusText: html === error_page ? 'Not found' : 'Ok',
       headers: {
         'content-type': 'text/html',
       },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ import {
   ServerConstructor,
   ServerType,
 } from '@fab/core'
-import { _log, InvalidConfigError, JSON5Config } from '@fab/cli'
+import { _log, InvalidConfigError, FabServerError, JSON5Config } from '@fab/cli'
 import { readFilesFromZip } from './utils'
 import v8_sandbox from './sandboxes/v8-isolate'
 import { Cache } from './cache'
@@ -50,7 +50,7 @@ class Server implements ServerType {
 
   async serve(runtimeType: SandboxType) {
     if (!(await fs.pathExists(this.filename))) {
-      throw new InvalidConfigError(`Could not find file '${this.filename}'`)
+      throw new FabServerError(`Could not find file '${this.filename}'`)
     }
     log(`Reading 💛${this.filename}💛...`)
 
@@ -62,7 +62,7 @@ class Server implements ServerType {
 
     const src_buffer = files['/server.js']
     if (!src_buffer) {
-      throw new InvalidConfigError('Malformed FAB. Missing /server.js')
+      throw new FabServerError('Malformed FAB. Missing /server.js')
     }
     const src = src_buffer.toString('utf8')
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,11 +16,12 @@ import { Cache } from './cache'
 import node_vm_sandbox from '@fab/sandbox-node-vm'
 import url from 'url'
 import http from 'http'
-import express from 'express'
+import express, { Express } from 'express'
 import concat from 'concat-stream'
 import fetch, { Request as NodeFetchRequest } from 'cross-fetch'
 import { pathToSHA512 } from 'file-to-sha512'
 import Stream from 'stream'
+import { watcher } from '@fab/cli'
 
 function isRequest(fetch_res: Request | Response): fetch_res is Request {
   return (
@@ -48,141 +49,161 @@ class Server implements ServerType {
     this.env = args.env
   }
 
-  async serve(runtimeType: SandboxType) {
+  async serve(runtimeType: SandboxType, watching: boolean = false) {
     if (!(await fs.pathExists(this.filename))) {
       throw new FabServerError(`Could not find file '${this.filename}'`)
     }
-    log(`Reading 💛${this.filename}💛...`)
 
-    const settings_overrides = await this.getSettingsOverrides()
+    let app: Express
+    let server: ReturnType<typeof http.createServer>
 
-    const files = await readFilesFromZip(this.filename)
+    const bootServer = async () => {
+      log(`Reading 💛${this.filename}💛...`)
+      const files = await readFilesFromZip(this.filename)
+      log.tick(`Done. Booting FAB server...`)
 
-    log.tick(`Done. Booting FAB server...`)
+      const settings_overrides = await this.getSettingsOverrides()
 
-    const src_buffer = files['/server.js']
-    if (!src_buffer) {
-      throw new FabServerError('Malformed FAB. Missing /server.js')
-    }
-    const src = src_buffer.toString('utf8')
-
-    const enhanced_fetch: FetchApi = async (url, init?) => {
-      const request_url = typeof url === 'string' ? url : url.url
-      if (request_url.startsWith('/')) {
-        // Need a smarter wau to re-enter the FAB, eventually...
-        return fetch(`http://localhost:${this.port}${request_url}`, init)
+      const src_buffer = files['/server.js']
+      if (!src_buffer) {
+        throw new FabServerError('Malformed FAB. Missing /server.js')
       }
+      const src = src_buffer.toString('utf8')
 
-      return fetch(url, init)
-    }
-
-    const renderer =
-      (await runtimeType) === SandboxType.v8isolate
-        ? await v8_sandbox(src)
-        : await node_vm_sandbox(src, enhanced_fetch)
-
-    const bundle_id = (await pathToSHA512(this.filename)).slice(0, 32)
-    const cache = new Cache()
-    // Support pre v0.2 FABs
-    if (typeof renderer.initialize === 'function')
-      renderer.initialize({ bundle_id, cache })
-
-    log.tick(`Done. Booting VM...`)
-
-    await new Promise((resolve, reject) => {
-      const app = express()
-
-      app.use((req, res, next) => {
-        req.pipe(
-          concat((data: any) => {
-            req.body = data.toString()
-            next()
-          })
-        )
-      })
-
-      app.all('*', async (req, res) => {
-        try {
-          const pathname = url.parse(req.url!).pathname!
-          if (pathname.startsWith('/_assets')) {
-            res.setHeader('Content-Type', getContentType(pathname))
-            res.setHeader('Cache-Control', 'immutable')
-            res.end(files[pathname])
-          } else {
-            const method = req.method
-            const headers: any = req.headers
-            const url = `${req.protocol}://${req.headers.host}${req.url}`
-            const fetch_req = new NodeFetchRequest(url, {
-              method,
-              headers,
-              ...(method === 'POST' ? { body: req.body } : {}),
-            })
-
-            const production_settings = renderer.metadata?.production_settings
-            // console.log({production_settings})
-            let fetch_res = await renderer.render(
-              // @ts-ignore
-              fetch_req as Request,
-              Object.assign({}, production_settings, settings_overrides)
-            )
-            if (isRequest(fetch_res)) {
-              fetch_res = await enhanced_fetch(fetch_res)
-            }
-            res.status(fetch_res.status)
-            // This is a NodeFetch response, which has this method, but
-            // the @fab/core types are from dom.ts, which doesn't. This
-            // was the easiest workaround for now.
-            // @ts-ignore
-            const response_headers = fetch_res.headers.raw()
-            // console.log({response_headers})
-            delete response_headers['content-encoding']
-            Object.keys(response_headers).forEach((header) => {
-              const values = response_headers[header]
-              res.set(header, values.length === 1 ? values[0] : values)
-            })
-
-            const body = fetch_res.body
-            if (body) {
-              if (typeof body.getReader === 'function') {
-                const reader = body.getReader()
-                let x
-                while ((x = await reader.read())) {
-                  const { done, value } = x
-                  if (done) break
-                  if (value) res.write(value)
-                }
-                res.end()
-              } else if (body instanceof Stream) {
-                await new Promise((resolve, reject) => {
-                  body.on('data', (chunk) => res.write(chunk))
-                  body.on('error', reject)
-                  body.on('end', resolve)
-                })
-                res.end()
-              } else {
-                const blob = await fetch_res.arrayBuffer()
-                res.send(Buffer.from(blob))
-              }
-            } else {
-              res.end()
-            }
-          }
-        } catch (e) {
-          console.log('ERROR')
-          console.log(e)
-          res.writeHead(500, 'Internal Error')
-          res.end()
+      const enhanced_fetch: FetchApi = async (url, init?) => {
+        const request_url = typeof url === 'string' ? url : url.url
+        if (request_url.startsWith('/')) {
+          // Need a smarter wau to re-enter the FAB, eventually...
+          return fetch(`http://localhost:${this.port}${request_url}`, init)
         }
 
-        log(`🖤${req.url}🖤`)
-      })
-      const server = http.createServer(app)
-      //   ? https.createServer({ key: this.key, cert: this.cert }, app)
-      server.listen(this.port, resolve)
-    })
+        return fetch(url, init)
+      }
 
-    log.tick(`Done.`)
-    log(`Listening on 💛http://localhost:${this.port}💛`)
+      const renderer =
+        (await runtimeType) === SandboxType.v8isolate
+          ? await v8_sandbox(src)
+          : await node_vm_sandbox(src, enhanced_fetch)
+
+      const bundle_id = (await pathToSHA512(this.filename)).slice(0, 32)
+      const cache = new Cache()
+      // Support pre v0.2 FABs
+      if (typeof renderer.initialize === 'function')
+        renderer.initialize({ bundle_id, cache })
+
+      log.tick(`Done. Booting VM...`)
+
+      await new Promise((resolve, reject) => {
+        app = express()
+
+        app.use((req, res, next) => {
+          req.pipe(
+            concat((data: any) => {
+              req.body = data.toString()
+              next()
+            })
+          )
+        })
+
+        app.all('*', async (req, res) => {
+          try {
+            const pathname = url.parse(req.url!).pathname!
+            if (pathname.startsWith('/_assets')) {
+              res.setHeader('Content-Type', getContentType(pathname))
+              res.setHeader('Cache-Control', 'immutable')
+              res.end(files[pathname])
+            } else {
+              const method = req.method
+              const headers: any = req.headers
+              const url = `${req.protocol}://${req.headers.host}${req.url}`
+              const fetch_req = new NodeFetchRequest(url, {
+                method,
+                headers,
+                ...(method === 'POST' ? { body: req.body } : {}),
+              })
+
+              const production_settings = renderer.metadata?.production_settings
+              // console.log({production_settings})
+              let fetch_res = await renderer.render(
+                // @ts-ignore
+                fetch_req as Request,
+                Object.assign({}, production_settings, settings_overrides)
+              )
+              if (isRequest(fetch_res)) {
+                fetch_res = await enhanced_fetch(fetch_res)
+              }
+              res.status(fetch_res.status)
+              // This is a NodeFetch response, which has this method, but
+              // the @fab/core types are from dom.ts, which doesn't. This
+              // was the easiest workaround for now.
+              // @ts-ignore
+              const response_headers = fetch_res.headers.raw()
+              // console.log({response_headers})
+              delete response_headers['content-encoding']
+              Object.keys(response_headers).forEach((header) => {
+                const values = response_headers[header]
+                res.set(header, values.length === 1 ? values[0] : values)
+              })
+
+              const body = fetch_res.body
+              if (body) {
+                if (typeof body.getReader === 'function') {
+                  const reader = body.getReader()
+                  let x
+                  while ((x = await reader.read())) {
+                    const { done, value } = x
+                    if (done) break
+                    if (value) res.write(value)
+                  }
+                  res.end()
+                } else if (body instanceof Stream) {
+                  await new Promise((resolve, reject) => {
+                    body.on('data', (chunk) => res.write(chunk))
+                    body.on('error', reject)
+                    body.on('end', resolve)
+                  })
+                  res.end()
+                } else {
+                  const blob = await fetch_res.arrayBuffer()
+                  res.send(Buffer.from(blob))
+                }
+              } else {
+                res.end()
+              }
+            }
+          } catch (e) {
+            console.log('ERROR')
+            console.log(e)
+            res.writeHead(500, 'Internal Error')
+            res.end()
+          }
+
+          log(`🖤${req.url}🖤`)
+        })
+
+        if (!server) {
+          if (watching) log.note(`Watching 💛${this.filename}💛 for changes...`)
+          server = http.createServer((req, res) => app(req, res))
+          //   ? https.createServer({ key: this.key, cert: this.cert }, app)
+          server.listen(this.port, resolve)
+        } else {
+          resolve()
+        }
+      })
+
+      log.tick(`Done.`)
+      log(`Listening on 💛http://localhost:${this.port}💛`)
+    }
+
+    if (watching) {
+      await watcher([this.filename], bootServer, {
+        awaitWriteFinish: {
+          stabilityThreshold: 500,
+        },
+      })
+    } else {
+      await bootServer()
+    }
   }
 
   private async getSettingsOverrides() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,6 +2495,21 @@ chokidar@^3.3.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
+chokidar@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.0.tgz#b30611423ce376357c765b9b8f904b9fba3c0be8"
+  integrity sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
@@ -6988,7 +7003,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.7:
+picomatch@^2.0.4, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -7425,6 +7440,13 @@ readdirp@~3.3.0:
   integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
   dependencies:
     picomatch "^2.0.7"
+
+readdirp@~3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
+  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 rechoir@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
Added `fab build --watch [dir]` and `fab serve --watch`:

This is the first step towards improving the DX of writing FAB plugins. Basically, I'm doing this:

```
fab build --watch output_dir --watch current-plugin.js
```

That'll just set up a `chokidar` loop and restart the whole `fab build` process when any file you mention changes. It's not super smart, so if a file ends up in the node require cache it won't get reloaded, but it _does_ work for plugins, `fab.config.json5` and any input directory. And it's actually pretty quick!

```
fab serve --watch
```

First up, if you forget to add `fab.zip` it now assumes that's what you meant. But now it just watches `fab.zip` and re-extracts it without having to restart the server. It works pretty well, but in future I'd like to expand this and actually parse the runtime plugins themselves.

Plenty more to do on this, but this is helping already.