### PR TITLE
Testing `replaceRequest` directive

### DIFF
--- a/packages/actions/src/runtime/index.ts
+++ b/packages/actions/src/runtime/index.ts
@@ -39,7 +39,7 @@ let Runtime: FABRuntime | undefined = undefined
 export const initialize = (server_context: FABServerContext) => {
   Runtime = FABRuntime.initialize(
     fab_metadata,
-    [...(runtimes as FabPluginRuntime[]), final_responder],
+    [...runtimes, final_responder],
     server_context
   )
 }

--- a/packages/input-nextjs/src/runtime.ts
+++ b/packages/input-nextjs/src/runtime.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import __generated from 'generated-nextjs-renderers.js'
 import { pathToRegexp } from 'path-to-regexp'
-import { FABRuntime, NO_RESPONSE_STATUS_CODE } from '@fab/core'
+import { FABRuntime, NO_RESPONSE_STATUS_CODE, Priority } from '@fab/core'
 
 const { renderers, MockExpressResponse, MockReq } = __generated
 
@@ -102,5 +102,5 @@ export default function InputNextJsRuntime({ Router }: FABRuntime) {
           : response
       },
     }
-  })
+  }, Priority.LATER)
 }

--- a/packages/plugin-render-html/src/runtime.ts
+++ b/packages/plugin-render-html/src/runtime.ts
@@ -1,5 +1,11 @@
 import { RenderHtmlMetadata } from './types'
-import { FABRuntime, FabSettings, matchPath, NO_RESPONSE_STATUS_CODE } from '@fab/core'
+import {
+  FABRuntime,
+  FabSettings,
+  matchPath,
+  NO_RESPONSE_STATUS_CODE,
+  Priority,
+} from '@fab/core'
 import { DEFAULT_INJECTIONS } from './constants'
 import { generateReplacements } from './injections/env'
 import { ITokens } from 'micromustache'
@@ -81,5 +87,5 @@ export default function RenderHTMLRuntime({
       }
 
     return undefined
-  })
+  }, Priority.LATER)
 }

--- a/packages/plugin-rewire-assets/src/runtime.ts
+++ b/packages/plugin-rewire-assets/src/runtime.ts
@@ -1,5 +1,11 @@
 import { RewireAssetsMetadata } from './types'
-import { FABRuntime, getCacheHeaders, matchPath, NON_IMMUTABLE_HEADERS } from '@fab/core'
+import {
+  FABRuntime,
+  getCacheHeaders,
+  matchPath,
+  NON_IMMUTABLE_HEADERS,
+  Priority,
+} from '@fab/core'
 
 export default function RewireAssetsRuntime({
   Router,
@@ -37,5 +43,5 @@ export default function RewireAssetsRuntime({
     }
 
     return undefined
-  })
+  }, Priority.LAST)
 }

--- a/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
+++ b/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
@@ -10,7 +10,7 @@ export default ({ Router }: FABRuntime) => {
 
   Router.on('/alt(/.*)?', async ({ request }) => {
     return {
-      replaceRequest: new Request('/index.html'),
+      replaceRequest: new Request('/alternative.html', request),
     }
   })
 }

--- a/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
+++ b/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
@@ -7,4 +7,10 @@ export default ({ Router }: FABRuntime) => {
       status: 200,
     })
   })
+
+  Router.on('/alt(/.*)?', async ({ request }) => {
+    return {
+      replaceRequest: new Request('/index.html'),
+    }
+  })
 }

--- a/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
+++ b/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
@@ -1,4 +1,4 @@
-import { FABRuntime } from '@fab/core'
+import { FABRuntime, Priority } from '@fab/core'
 
 export default ({ Router }: FABRuntime) => {
   Router.on('/hello/:whom?', async ({ params }) => {
@@ -8,9 +8,13 @@ export default ({ Router }: FABRuntime) => {
     })
   })
 
-  Router.on('/alt(/.*)?', async ({ request }) => {
-    return {
-      replaceRequest: new Request('/alternative.html', request),
-    }
-  })
+  Router.on(
+    '/alt(/.*)?',
+    async ({ url, request }) => {
+      return {
+        replaceRequest: new Request(`${url.origin}/alternative.html`, request),
+      }
+    },
+    Priority.FIRST
+  )
 }

--- a/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
+++ b/tests/e2e/fixtures/server-side-logic/fab-plugins/hello-world.ts
@@ -17,4 +17,13 @@ export default ({ Router }: FABRuntime) => {
     },
     Priority.FIRST
   )
+
+  Router.on(
+    '/mutate-url-doesnt-work',
+    async ({ url }) => {
+      url.pathname = '/alternative.html'
+      return undefined
+    },
+    Priority.FIRST
+  )
 }

--- a/tests/e2e/fixtures/server-side-logic/fab.config.json5
+++ b/tests/e2e/fixtures/server-side-logic/fab.config.json5
@@ -1,7 +1,7 @@
 {
   plugins: {
     '@fab/input-static': { dir: 'public' },
-    '@fab/plugin-render-html': { fallback: false },
+    '@fab/plugin-render-html': { fallback: '/index.html' },
     '@fab/plugin-rewire-assets': {},
     './fab-plugins/hello-world': {},
     './fab-plugins/add-bundle-id': {},

--- a/tests/e2e/fixtures/server-side-logic/public/alternative.html
+++ b/tests/e2e/fixtures/server-side-logic/public/alternative.html
@@ -5,6 +5,6 @@
     <title>ALTERNATIVE HTML</title>
   </head>
   <body>
-    <h1>This should be served under /alt URLs</h1>
+    <h1>This should be served under /alt URLs.</h1>
   </body>
 </html>

--- a/tests/e2e/fixtures/server-side-logic/public/alternative.html
+++ b/tests/e2e/fixtures/server-side-logic/public/alternative.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>INDEX HTML</title>
+    <title>ALTERNATIVE HTML</title>
   </head>
   <body>
-    <h1>This is the default fallback.</h1>
+    <h1>This should be served under /alt URLs</h1>
   </body>
 </html>

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -101,6 +101,9 @@ describe('Server-side logic tests', () => {
 
       const alt_sub_response = await request('', '/alt/fab', port)
       expect(alt_sub_response).toEqual(alt_response)
+
+      const wrong_mutation_response = await request('', '/mutate-url-doesnt-work', port)
+      expect(wrong_mutation_response).toEqual(homepage_response)
     })
 
     it('should hit a streaming endpoint', async () => {

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -95,14 +95,12 @@ describe('Server-side logic tests', () => {
 
       const alt_response = await request('', '/alt', port)
       expect(alt_response).not.toEqual(homepage_response)
-      expect(homepage_response).toContain(`<title>ALTERNATIVE HTML</title>`)
-      expect(homepage_response).toContain(
-        `<h1>This should be served under /alt URLs.</h1>`
-      )
-      expect(homepage_response).toContain(`window.FAB_SETTINGS={}`)
+      expect(alt_response).toContain(`<title>ALTERNATIVE HTML</title>`)
+      expect(alt_response).toContain(`<h1>This should be served under /alt URLs.</h1>`)
+      expect(alt_response).toContain(`window.FAB_SETTINGS={}`)
 
       const alt_sub_response = await request('', '/alt/fab', port)
-      expect(alt_sub_response).not.toEqual(alt_response)
+      expect(alt_sub_response).toEqual(alt_response)
     })
 
     it('should hit a streaming endpoint', async () => {

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -72,7 +72,7 @@ describe('Server-side logic tests', () => {
       cancelServer()
     })
 
-    it('should hit Hello World', async () => {
+    it('should hit the Hello World plugin', async () => {
       const bundle_id = (await pathToSHA512(`${cwd}/fab.zip`)).slice(0, 32)
 
       const homepage_headers = await request('-I', '/', port)
@@ -92,6 +92,17 @@ describe('Server-side logic tests', () => {
       const hello_fab_response = await request('', '/hello/fab', port)
       expect(hello_fab_response).not.toEqual(homepage_response)
       expect(hello_fab_response).toContain('HELLO FAB!')
+
+      const alt_response = await request('', '/alt', port)
+      expect(alt_response).not.toEqual(homepage_response)
+      expect(homepage_response).toContain(`<title>ALTERNATIVE HTML</title>`)
+      expect(homepage_response).toContain(
+        `<h1>This should be served under /alt URLs.</h1>`
+      )
+      expect(homepage_response).toContain(`window.FAB_SETTINGS={}`)
+
+      const alt_sub_response = await request('', '/alt/fab', port)
+      expect(alt_sub_response).not.toEqual(alt_response)
     })
 
     it('should hit a streaming endpoint', async () => {

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -81,8 +81,8 @@ describe('Server-side logic tests', () => {
       expect(await request('-I', '/hello', port)).toContain(`HTTP/1.1 200 OK`)
 
       const homepage_response = await request('', '/', port)
-      expect(homepage_response).toContain(`<title>HULLO</title>`)
-      expect(homepage_response).toContain(`<h1>HAI</h1>`)
+      expect(homepage_response).toContain(`<title>INDEX HTML</title>`)
+      expect(homepage_response).toContain(`<h1>This is the default fallback.</h1>`)
       expect(homepage_response).toContain(`window.FAB_SETTINGS={}`)
 
       const hello_response = await request('', '/hello', port)


### PR DESCRIPTION
A way of adding an early middleware to use more than the one fallback file (i.e. most routes render `/index.html` but `/alt/xyz` renders `/alternative.html`).

The syntax to do this looks like this:

```js
  Router.on(
    '/alt(/.*)?',
    async ({ url, request }) => {
      return {
        replaceRequest: new Request(`${url.origin}/alternative.html`, request),
      }
    },
    Priority.FIRST
  )
```

Added a test for it, and a test to make sure that the dodgy way (mutating the `url` object) doesn't work.