### PR TITLE
Improve docs to return a new Request rather than a fetch for proxying

### DIFF
--- a/docs/content/en/guides/adding-server-side-logic.md
+++ b/docs/content/en/guides/adding-server-side-logic.md
@@ -18,7 +18,7 @@ It can be quite convenient to proxy your backend API behind a route on your fron
 ```js[proxy-api.js]
 export default ({ Router }) => {
   Router.on('/api/:route(.*)', ({ params }) => {
-    return fetch(`https://api.example.com/${params.route}`)
+    return new Request(`https://api.example.com/${params.route}`)
   })
 }
 ```
@@ -150,7 +150,7 @@ export default function({ Router }) {
     // Build up our URL to proxy to using our API_HOST and our original request's pathname
     const forwarded_url = `https://${settings.API_HOST}${url.pathname}`
     // Create a new Request with the new URL and our updated headers
-    return fetch(new Request(forwarded_url, forwarded_request))
+    return new Request(forwarded_url, forwarded_request)
   })
 }
 ```


### PR DESCRIPTION
The FAB specification allows the return of a Request to proxy that, which may allow FAB hosting platform to better optimise those. So it is preferred to return a Request than to return the fetch of that Request if you don't need to change the response in any way.