### PR TITLE
Testing: fixing the public packages test

### DIFF
--- a/.github/workflows/public-consumer.yml
+++ b/.github/workflows/public-consumer.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - prerelease
 
 jobs:
   public_package_build:

--- a/packages/input-nextjs/package.json
+++ b/packages/input-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/input-nextjs",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.6.p1",
   "description": "Module to kick off a FAB build from a NextJS project",
   "keywords": [
     "aws",

--- a/packages/plugin-rewire-assets/package.json
+++ b/packages/plugin-rewire-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/plugin-rewire-assets",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.6.p1",
   "description": "Module to handle files outside _assets",
   "keywords": [
     "assets",

--- a/packages/plugin-rewire-assets/src/runtime.ts
+++ b/packages/plugin-rewire-assets/src/runtime.ts
@@ -38,7 +38,11 @@ export default function RewireAssetsRuntime({
         Object.entries(NON_IMMUTABLE_HEADERS).forEach(([k, v]) =>
           response.headers.set(k, v)
         )
-        return response
+        // The following lines ought to be removed, but something is causing a failure
+        // with NextJS and this. I have a feeling it is related to the recent node-fetch
+        // security update but haven't tracked it down yet.
+        const body = await response.body
+        return new Response(body, response)
       }
     }
 

--- a/tests/e2e/nextjs.test.ts
+++ b/tests/e2e/nextjs.test.ts
@@ -126,7 +126,7 @@ describe('Nextjs E2E Test', () => {
       expect(homepage_response).toContain(`window.FAB_SETTINGS={}`)
     })
 
-    it('should return a correct cache headers on assets', async () => {
+    it.skip('should return a correct cache headers on assets', async () => {
       const index_paths = await globby('static/chunks/pages/index-*.js', {
         cwd: path.join(cwd, '.next'),
       })

--- a/tests/e2e/nextjs.test.ts
+++ b/tests/e2e/nextjs.test.ts
@@ -126,7 +126,7 @@ describe('Nextjs E2E Test', () => {
       expect(homepage_response).toContain(`window.FAB_SETTINGS={}`)
     })
 
-    it.skip('should return a correct cache headers on assets', async () => {
+    it('should return a correct cache headers on assets', async () => {
       const index_paths = await globby('static/chunks/pages/index-*.js', {
         cwd: path.join(cwd, '.next'),
       })


### PR DESCRIPTION
Right now we have two tests on CI, one that uses the locally-built packages, and one that uses whatever's on `npm` under the `latest` tag. The public packages one only runs on master, which means sometimes stuff breaks outside of a PR flow.

I'm thinking I might use this branch as a prerelease (hence the name) when new package versions are going to break the tests, so I can keep `master` green a bit more often...

For now though, just trying to fix this one test in front of me.