### PR TITLE
E2E Testing chunking assets

### DIFF
--- a/packages/sandbox-node-vm/src/index.ts
+++ b/packages/sandbox-node-vm/src/index.ts
@@ -25,6 +25,8 @@ export function HybridReadableStream(...args: any[]) {
     },
   })
 }
+// @ts-ignore ho boy I don't want to do this
+global.ReadableStream = WebReadableStream
 
 export default async (src: string, enhanced_fetch: any): Promise<FabSpecExports> => {
   const sandbox = {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
     "get-stream": "^5.1.0",
     "http-proxy": "^1.18.1",
     "node-cache": "^5.1.0",
+    "readable-stream-node-to-web": "^1.0.1",
     "yauzl": "^2.10.0"
   },
   "publishConfig": {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -89,9 +89,14 @@ class Server implements ServerType {
         )
         return Object.create(response, {
           body: {
-            get() {
-              return nodeToWebStream(response.body)
-            },
+            value: Object.create(response.body, {
+              getReader: {
+                get() {
+                  const webStream = nodeToWebStream(response.body)
+                  return webStream.getReader.bind(webStream)
+                },
+              },
+            }),
           },
         })
       }

--- a/tests/e2e/create-react-app.test.ts
+++ b/tests/e2e/create-react-app.test.ts
@@ -248,6 +248,12 @@ describe('Create React App E2E Test', () => {
       expect(await request('-I', '/bigfile.a1b2c3d4e5.immutable')).toContain(
         `HTTP/1.1 200 OK`
       )
+
+      const response_one = await request('', '/bigfile.mutable')
+      expect(response_one).toEqual(big_file)
+
+      const response_two = await request('', '/bigfile.a1b2c3d4e5.immutable')
+      expect(response_two).toEqual(big_file)
     })
 
     afterAll(async () => {

--- a/tests/e2e/server-side-logic.test.ts
+++ b/tests/e2e/server-side-logic.test.ts
@@ -1,4 +1,4 @@
-import path from 'pat\h'
+import path from 'path'
 import {
   buildFab,
   cancelServer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7504,6 +7504,11 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
+readable-stream-node-to-web@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
+  integrity sha1-i3YU+qFGXr+g2pucpjA/onBzt88=
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"


### PR DESCRIPTION
Following on from #241, I've got an E2E test failing now, with the following message:

`curl -I localhost:3000/bigfile.a1b2c3d4e5.immutable`

```
ERROR
TypeError: stream.getReader is not a function
    at Object.start (evalmachine.<anonymous>:11310:43)
    at Call (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/helpers.ts:62:35)
    at InvokeOrNoop (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/helpers.ts:121:10)
    at startAlgorithm (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:342:12)
    at SetUpReadableStreamDefaultController (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:316:23)
    at SetUpReadableStreamDefaultControllerFromUnderlyingSource (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:352:3)
    at new ReadableStream (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream.ts:116:7)
    at new HybridReadableStream (/home/glen/src/projects/packages/sandbox-node-vm/src/index.ts:17:26)
    at concatenateReadableStreams (evalmachine.<anonymous>:11304:16)
    at evalmachine.<anonymous>:11292:47
        [Server] /bigfile.a1b2c3d4e5.immutable
        [Server] /_assets/bigfile.618be48f9.mutable~1
        [Server] /_assets/bigfile.618be48f9.mutable~2
        [Server] /_assets/bigfile.618be48f9.mutable~3
```

`curl -I localhost:3000/bigfile.mutable`

```
ERROR
TypeError: stream.getReader is not a function
    at Object.start (evalmachine.<anonymous>:11310:43)
    at Call (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/helpers.ts:62:35)
    at InvokeOrNoop (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/helpers.ts:121:10)
    at startAlgorithm (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:342:12)
    at SetUpReadableStreamDefaultController (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:316:23)
    at SetUpReadableStreamDefaultControllerFromUnderlyingSource (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream/default-controller.ts:352:3)
    at new ReadableStream (/home/glen/src/projects/fab/node_modules/web-streams-polyfill/src/lib/readable-stream.ts:116:7)
    at new HybridReadableStream (/home/glen/src/projects/packages/sandbox-node-vm/src/index.ts:17:26)
    at concatenateReadableStreams (evalmachine.<anonymous>:11304:16)
    at evalmachine.<anonymous>:11292:47
        [Server] /bigfile.mutable
```

Best way to reproduce, go into the `tests` directory and do:

```
# NOTE: ONLY THE FIRST TIME
yarn test create-react-app
# TO RERUN, USE THIS:
FAB_E2E_SKIP_CREATE=true yarn test create-react-app
```

Then, to get a better view on the failure:

```
cd e2e/workspace/cra-test
npx fab serve
curl -I localhost:3000/bigfile.mutable
```

I'm not sure on the problem, @yacinehmito. Potentially related to #253?