### PR TITLE
Add `MockExpressResponse.hasHeader` (Express) shim

### DIFF
--- a/packages/input-nextjs/shims/mock-express-response/index.js
+++ b/packages/input-nextjs/shims/mock-express-response/index.js
@@ -863,6 +863,17 @@ MockExpressResponse.prototype.get = function(field) {
 }
 
 /**
+ * Check if header `field` is present.
+ *
+ * @param {String} field
+ * @return {Boolean}
+ * @api public
+ */
+MockExpressResponse.prototype.hasHeader = function(field) {
+  return !!this.getHeader(field)
+}
+
+/**
  * Clear cookie `name`.
  *
  * @param {String} name


### PR DESCRIPTION
Trying to render a NextJS app with `getServerSideProps` will yield the
following error:

```
ERROR: NextJS renderer crashed
TypeError: t.hasHeader is not a function
```

See https://github.com/fab-spec/fab/issues/220 and https://github.com/serverless-nextjs/serverless-next.js/pull/342#issuecomment-609999944

How about tests for this? I could only find e2e tests, is that the preferred way here?