### PR TITLE
support ts build plugins

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -49,6 +49,7 @@
     "execa": "^4.0.2",
     "fs-extra": "^8.1.0",
     "memfs": "^3.0.4",
+    "node-eval": "^2.0.0",
     "path-browserify": "^1.0.0",
     "rollup": "^1.27.10",
     "rollup-plugin-hypothetical": "^2.1.0",

--- a/packages/actions/src/BuildPluginCompiler.ts
+++ b/packages/actions/src/BuildPluginCompiler.ts
@@ -1,0 +1,141 @@
+import { ProtoFab, BuildPlugin, RuntimePlugin } from '@fab/core'
+import { _log, BuildFailedError } from '@fab/cli'
+import { rollupCompile } from './rollup'
+import nodeEval from 'node-eval'
+import path from 'path'
+
+const log = _log(`BuildPluginCompiler`)
+
+export class BuildPluginCompiler {
+  static async compileAndExecute(
+    proto_fab: ProtoFab,
+    plugins: BuildPlugin[],
+    config_path: string,
+    skip_cache: boolean
+  ): Promise<RuntimePlugin[]> {
+    log.time(() => `Compiling and executing your 💛build plugins💛:`)
+
+    const code = await compile(config_path, proto_fab, plugins)
+
+    const dynamic_runtimes: RuntimePlugin[] = await execute(
+      code,
+      proto_fab,
+      config_path,
+      skip_cache
+    )
+
+    log.time((d) => `Done in ${d}.`)
+
+    return dynamic_runtimes
+  }
+}
+
+async function compile(config_path: string, proto_fab: ProtoFab, plugins: BuildPlugin[]) {
+  const warnings: string[] = []
+  const indexFile = path.join(path.dirname(config_path), 'index.ts')
+  const {
+    output: [output, ...chunks],
+  } = await rollupCompile(indexFile, {
+    output: { format: 'cjs', exports: 'named' },
+    hypotheticals: {
+      [indexFile]: generateBuildIndexScript(plugins),
+      ...proto_fab.hypotheticals,
+    },
+    additional: {
+      onwarn(warning, handler) {
+        if (warning.code === 'UNRESOLVED_IMPORT') {
+          warnings.push(
+            `Could not find module '${warning.source}' during build of '${warning.importer}'`
+          )
+        } else {
+          handler(warning)
+        }
+      },
+      // let node_modules resolve themselves, no need to bundle them
+      external: (mid) => /(node_modules)/g.test(mid),
+    },
+  })
+
+  if (warnings.length > 0) {
+    throw new BuildFailedError(
+      `Errors encountered during Rollup build:\n\n  - ${warnings.join('\n  - ')}\n`
+    )
+  }
+
+  if (chunks.length > 0) {
+    log.error(`WARNING: Didn't expect there to be more than one chunk created! Got:`)
+    console.log(chunks)
+  }
+
+  return output.code
+}
+
+async function execute(
+  code: string,
+  proto_fab: ProtoFab,
+  config_path: string,
+  skip_cache: boolean
+) {
+  try {
+    /**
+     * the second arg doesn't actually have to exist, but node-eval
+     * requires a path to a .js file be provided if the code to
+     * evaluate contains any `require` statements... ¯\_(ツ)_/¯
+     * */
+    const { dynamic_runtimes_promise } = nodeEval(
+      code,
+      path.join(path.dirname(config_path), 'index.js'),
+      {
+        proto_fab,
+        config_path,
+        skip_cache,
+      }
+    )
+
+    const result = await dynamic_runtimes_promise
+
+    return result
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new BuildFailedError(`Error occurred requiring a build plugin. Error message:
+        ${e.message}`)
+    }
+
+    throw new BuildFailedError(`An unhandled error occurred. Error message:
+      ${e.message}`)
+  }
+}
+
+function generateBuildIndexScript(buildPlugins: BuildPlugin[]) {
+  const importStatements = [] as string[]
+  const executionStatements = [] as string[]
+
+  buildPlugins.forEach((plugin, index) => {
+    importStatements.push(generateImportStatement(plugin, index))
+    executionStatements.push(generateExectionStatement(plugin, index))
+  })
+
+  const result = `
+  ${importStatements.join('\n')}
+
+  let dynamic_runtimes = [];
+
+  const dynamic_runtimes_promise = (async function() {
+    ${executionStatements.join('\n')}
+    return dynamic_runtimes
+  })();
+
+  module.exports = { dynamic_runtimes_promise };
+`
+  return result
+}
+
+function generateImportStatement(plugin: BuildPlugin, index: number) {
+  return `import { build as build_${index} } from '${plugin.builder}';`
+}
+
+function generateExectionStatement(plugin: BuildPlugin, index: number) {
+  return `const builder_output_${index} = await build_${index}(${JSON.stringify(
+    plugin.plugin_args
+  )}, proto_fab, config_path, skip_cache); dynamic_runtimes = dynamic_runtimes.concat(builder_output_${index} || []);`
+}

--- a/packages/actions/src/Typecheck.ts
+++ b/packages/actions/src/Typecheck.ts
@@ -3,22 +3,17 @@ import execa from 'execa'
 import path from 'path'
 import tmp from 'tmp-promise'
 import fs from 'fs-extra'
-import { RuntimePlugin } from '@fab/core'
 
 const log = _log('Typecheck')
 
 export class Typecheck {
-  static startTypecheck(
-    config_path: string,
-    plugins: RuntimePlugin[],
-    skip_typecheck: boolean
-  ) {
+  static startTypecheck(config_path: string, plugins: string[], skip_typecheck: boolean) {
     if (skip_typecheck) {
       log(`🖤Skipping.🖤`)
       return Typecheck.Noop
     }
 
-    const ts_plugins = plugins.map((p) => p.runtime).filter((r) => r.match(/\.tsx?$/))
+    const ts_plugins = plugins.filter((r) => r.match(/\.tsx?$/))
 
     if (ts_plugins.length === 0) {
       log(`🖤No Typescript plugins detected. Skipping.🖤`)

--- a/packages/actions/src/declarations.d.ts
+++ b/packages/actions/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-eval'

--- a/packages/actions/test/actions/BuildPluginCompiler.test.ts
+++ b/packages/actions/test/actions/BuildPluginCompiler.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai'
+import { BuildPluginCompiler } from '../../src/BuildPluginCompiler'
+import Builder from '../../src/Builder'
+import { JSON5Config } from '@fab/cli'
+import { ProtoFab, BuildPlugin } from '@fab/core'
+
+describe('BuildPluginCompiler', function() {
+  it('should compile and execute the build plugins from the fixtures directory', async () => {
+    const local_plugins = `${__dirname}/../fixtures/fab.local-plugins.json5`
+    const config_path = `${__dirname}/../fixtures/fab.local-plugins.json5`
+
+    const config = (await JSON5Config.readFrom(local_plugins)).data
+
+    const { build_plugins } = await Builder.getPlugins(config_path, config)
+
+    const expected_build_plugin_names = [
+      'build-and-render',
+      'build-only',
+      'typescript-example',
+      'build-with-dynamic-runtimes',
+    ]
+
+    build_plugins.forEach((plugin, index) => {
+      expect(plugin.builder).to.have.string(expected_build_plugin_names[index])
+    })
+
+    const proto_fab = new ProtoFab()
+    const dynamic_runtime_plugins = await BuildPluginCompiler.compileAndExecute(
+      proto_fab,
+      build_plugins as BuildPlugin[],
+      config_path,
+      false
+    )
+
+    expect(dynamic_runtime_plugins).to.deep.equal([
+      {
+        runtime: './plugins/foo',
+        plugin_args: {
+          somewhere: 'over the rainbow',
+        },
+      },
+    ])
+  })
+})

--- a/packages/actions/test/actions/Builder.test.ts
+++ b/packages/actions/test/actions/Builder.test.ts
@@ -17,7 +17,7 @@ describe('Builder', () => {
     )
 
     expect(
-      result.map(({ plugin_name, builder, plugin_args, runtime }) => [
+      result.plugins.map(({ plugin_name, builder, plugin_args, runtime }) => [
         plugin_name,
         plugin_args,
         !!builder,
@@ -29,8 +29,9 @@ describe('Builder', () => {
       ['./plugins/runtime-only', { thirdly: 'this' }, false, true],
       ['./plugins/empty', { set: 'it up' }, false, false],
       ['./plugins/typescript-example', { the_time_is: 'NOW!' }, true, true],
+      ['./plugins/build-with-dynamic-runtimes', { no_args: 'necessary' }, true, false],
     ])
-    expect(result.flatMap((p) => p.runtime || [])).to.deep.equal([
+    expect(result.plugins.flatMap((p) => p.runtime || [])).to.deep.equal([
       path.resolve(`${__dirname}/../fixtures/plugins/build-and-render/runtime.js`),
       path.resolve(`${__dirname}/../fixtures/plugins/runtime-only.js`),
       path.resolve(`${__dirname}/../fixtures/plugins/typescript-example/runtime.ts`),

--- a/packages/actions/test/fixtures/fab.local-plugins.json5
+++ b/packages/actions/test/fixtures/fab.local-plugins.json5
@@ -15,5 +15,8 @@
     './plugins/typescript-example': {
       the_time_is: 'NOW!',
     },
+    './plugins/build-with-dynamic-runtimes': {
+      no_args: 'necessary'
+    },
   },
 }

--- a/packages/actions/test/fixtures/plugins/build-with-dynamic-runtimes/build.ts
+++ b/packages/actions/test/fixtures/plugins/build-with-dynamic-runtimes/build.ts
@@ -1,0 +1,12 @@
+import { FabBuildStep } from '@fab/core/lib'
+
+export const build: FabBuildStep = async function build() {
+  return [
+    {
+      runtime: './plugins/foo',
+      plugin_args: {
+        somewhere: 'over the rainbow',
+      },
+    },
+  ]
+}

--- a/packages/actions/test/fixtures/plugins/typescript-example/build.ts
+++ b/packages/actions/test/fixtures/plugins/typescript-example/build.ts
@@ -6,5 +6,7 @@ export const build: FabBuildStep<TsExampleArgs, TsExampleMetadata> = async (
   proto_fab
 ) => {
   /* This line is fully typesafe! */
-  proto_fab.metadata.ts_test.what_time_is_it = args.the_time_is
+  proto_fab.metadata.ts_test = {
+    what_time_is_it: args.the_time_is,
+  }
 }

--- a/packages/cli/test/commands/build.test.ts
+++ b/packages/cli/test/commands/build.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@oclif/test'
 
-describe('build', () => {
+describe('build', function() {
+  this.timeout(10000)
   test
     .stdout()
     .command(['build'])

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,9 +39,21 @@ export interface PluginMetadata {
 export type LoadedPlugin = {
   plugin_name: string
   plugin_args: PluginArgs
-  builder: FabBuildStep | undefined
+  builder: string | undefined
   runtime: string | undefined
 }
+
+export type PluginLoadResult = {
+  plugins: LoadedPlugin[]
+  build_plugins: LoadedPlugin[]
+  runtime_plugins: LoadedPlugin[]
+}
+
+export type BuildPlugin = {
+  plugin_args: PluginArgs
+  builder: string
+}
+
 export type RuntimePlugin = {
   plugin_args: PluginArgs
   runtime: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -6382,6 +6382,13 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+node-eval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/node-eval/-/node-eval-2.0.0.tgz#ae1d1299deb4c0e41352f9528c1af6401661d37f"
+  integrity sha512-Ap+L9HznXAVeJj3TJ1op6M6bg5xtTq8L5CU/PJxtkhea/DrIxdTknGKIECKd/v/Lgql95iuMAYvIzBNd0pmcMg==
+  dependencies:
+    path-is-absolute "1.0.1"
+
 node-fetch-npm@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
@@ -7021,7 +7028,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
+path-is-absolute@1.0.1, path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=


### PR DESCRIPTION
Fixes #66 

This changes the `Builder.build` action in the following ways:
* No longer run build plugins during plugin discovery
* Instead, send build plugins to BuildPluginCompiler
* BuildPluginCompiler compiles all build plugins using same rollup config as runtime plugins
* BuildPluginCompiler then executes the bundle using `node-eval`
* Add typechecking for both runtime and build plugins

Feedback definitely welcome 😄 