### PR TITLE
Don't set chunked transfer-encoding if content-length is set.

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -166,10 +166,13 @@ class Server implements ServerType {
                 res.set(header, values.length === 1 ? values[0] : values)
               })
 
+              const shouldSetChunkedTransferEncoding =
+                !response_headers['content-length'] &&
+                !response_headers['transfer-encoding']
               const body = fetch_res.body
               if (body) {
                 if (typeof body.getReader === 'function') {
-                  if (!response_headers['transfer-encoding'])
+                  if (shouldSetChunkedTransferEncoding)
                     res.set('transfer-encoding', 'chunked')
 
                   const reader = body.getReader()
@@ -187,7 +190,7 @@ class Server implements ServerType {
                   }
                   res.end()
                 } else if (body instanceof Stream) {
-                  if (!response_headers['transfer-encoding'])
+                  if (shouldSetChunkedTransferEncoding)
                     res.set('transfer-encoding', 'chunked')
 
                   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Per [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.3.3)

       If a message is received with both a Transfer-Encoding and a
       Content-Length header field, the Transfer-Encoding overrides the
       Content-Length.  Such a message might indicate an attempt to
       perform request smuggling (Section 9.5) or response splitting
       (Section 9.4) and ought to be handled as an error.  A sender MUST
       remove the received Content-Length field prior to forwarding such
       a message downstream.

This is to fix an error with Cypress tests wherein running the tests against a `fab serve`d site errors on assets with both a `content-length` and `transfer-encoding`