### PR TITLE
Expo init fixes

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/1.0.0-rc.7.p2 linux-x64 node-v14.3.0
+@fab/cli/1.0.0-rc.7.p3 linux-x64 node-v14.3.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -65,7 +65,7 @@ EXAMPLES
   $ fab build --watch dist --watch fab.config.json5
 ```
 
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p2/lib/commands/build.js)_
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/build.js)_
 
 ## `fab deploy [FILE]`
 
@@ -102,7 +102,7 @@ EXAMPLE
   $ fab deploy fab.zip
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p2/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -143,7 +143,7 @@ EXAMPLES
   $ fab init --config=fab.config.json5
 ```
 
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p2/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/init.js)_
 
 ## `fab package [FILE]`
 
@@ -172,7 +172,7 @@ EXAMPLE
   $ fab package --target=aws-lambda-edge fab.zip
 ```
 
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p2/lib/commands/package.js)_
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/package.js)_
 
 ## `fab serve [FILE]`
 
@@ -211,6 +211,6 @@ EXAMPLES
   $ fab serve --env=staging fab.zip
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p2/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g @fab/cli
 $ fab COMMAND
 running command...
 $ fab (-v|--version|version)
-@fab/cli/1.0.0-rc.7.p3 linux-x64 node-v14.3.0
+@fab/cli/1.0.0-rc.7.p4wq linux-x64 node-v14.3.0
 $ fab --help [COMMAND]
 USAGE
   $ fab COMMAND
@@ -65,7 +65,7 @@ EXAMPLES
   $ fab build --watch dist --watch fab.config.json5
 ```
 
-_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/build.js)_
+_See code: [lib/commands/build.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p4wq/lib/commands/build.js)_
 
 ## `fab deploy [FILE]`
 
@@ -102,7 +102,7 @@ EXAMPLE
   $ fab deploy fab.zip
 ```
 
-_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/deploy.js)_
+_See code: [lib/commands/deploy.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p4wq/lib/commands/deploy.js)_
 
 ## `fab help [COMMAND]`
 
@@ -143,7 +143,7 @@ EXAMPLES
   $ fab init --config=fab.config.json5
 ```
 
-_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/init.js)_
+_See code: [lib/commands/init.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p4wq/lib/commands/init.js)_
 
 ## `fab package [FILE]`
 
@@ -172,7 +172,7 @@ EXAMPLE
   $ fab package --target=aws-lambda-edge fab.zip
 ```
 
-_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/package.js)_
+_See code: [lib/commands/package.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p4wq/lib/commands/package.js)_
 
 ## `fab serve [FILE]`
 
@@ -211,6 +211,6 @@ EXAMPLES
   $ fab serve --env=staging fab.zip
 ```
 
-_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p3/lib/commands/serve.js)_
+_See code: [lib/commands/serve.js](https://github.com/fab-spec/fab/blob/v1.0.0-rc.7.p4wq/lib/commands/serve.js)_
 
 <!-- commandsstop -->

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "1.0.0-rc.7.p3",
+  "version": "1.0.0-rc.7.p4wq",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "1.0.0-rc.7.p2",
+  "version": "1.0.0-rc.7.p3",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",

--- a/packages/cli/src/Initializer/frameworks.ts
+++ b/packages/cli/src/Initializer/frameworks.ts
@@ -62,14 +62,16 @@ export const Frameworks = {
 
       try {
         await execa.command(`expo-cli -V`)
-        log(`Detected 💛expo-cli💛 installed locally, proceeding...`)
+        log(
+          `💚Note:💚 your project doesn't explicitly depend on 💛expo-cli💛, but it is installed globally. We will add it as a 💛devDependency💛 since it makes builing this project easier in other places...`
+        )
         return []
       } catch (e) {
         log(
-          `❤️WARNING:❤️ your project doesn't depend on 💛expo-cli💛, and it doesn't seem to be installed locally. Adding it as a 💛devDependency💛...`
+          `❤️WARNING:❤️ your project doesn't depend on 💛expo-cli💛, and it doesn't seem to be installed globally. Adding it as a 💛devDependency💛...`
         )
-        return ['expo-cli']
       }
+      return ['expo-cli']
     },
   }),
   Next9: ({

--- a/packages/cli/src/Initializer/frameworks.ts
+++ b/packages/cli/src/Initializer/frameworks.ts
@@ -63,7 +63,7 @@ export const Frameworks = {
       try {
         await execa.command(`expo-cli -V`)
         log(
-          `💚Note:💚 your project doesn't explicitly depend on 💛expo-cli💛, but it is installed globally. We will add it as a 💛devDependency💛 since it makes builing this project easier in other places...`
+          `💚Note:💚 your project doesn't explicitly depend on 💛expo-cli💛, but it is installed globally. We will add it as a 💛devDependency💛 since it makes this project more portable...`
         )
         return []
       } catch (e) {

--- a/packages/cli/src/Initializer/utils.ts
+++ b/packages/cli/src/Initializer/utils.ts
@@ -1,4 +1,5 @@
 import { StringMap } from './constants'
+import { _log } from '../helpers'
 
 const isBuildScript = (script_name: string) => script_name.match(/^build/)
 
@@ -24,3 +25,5 @@ export const mergeScriptsAfterBuild = (
   if (!merged) Object.assign(merged_scripts, framework_scripts)
   return merged_scripts
 }
+
+export const log = _log('Initializer')


### PR DESCRIPTION
If you don't have `expo-cli` installed globally, this `fab init` wasn't working. Now it does.