### PR TITLE
Fix environment variables config snippet

### DIFF
--- a/docs/content/en/kb/environment-variables.md
+++ b/docs/content/en/kb/environment-variables.md
@@ -72,9 +72,9 @@ To use the same environment variables during development, it's recommended to ad
 // src/config.js
 
 const lookupEnvVar = (name) => {
-  // Use FAB_SETTINGS if defined
-  if (typeof FAB_SETTINGS === 'object') {
-    return FAB_SETTINGS[name]
+  // Use window.FAB_SETTINGS if defined
+  if (typeof window.FAB_SETTINGS === 'object') {
+    return window.FAB_SETTINGS[name]
 
     // Otherwise use process.env
   } else {


### PR DESCRIPTION
The config code snippet provided in the documentation on [accessing-environment-variables-at-runtime](https://fab.dev/kb/environment-variables#accessing-environment-variables-at-runtime) causes an error as `FAB_SETTINGS` is undefined:

![image](https://user-images.githubusercontent.com/19183324/97378910-9fbf7900-1917-11eb-9579-43becfa6e406.png)

I'm correcting the snippet so that instances of `FAB_SETTINGS` read `window.FAB_SETTINGS` instead.