### PR TITLE
Do not remove cache-control header in Lambda wrapper

### DIFF
--- a/packages/deployer-aws-lambda/templates/index.js
+++ b/packages/deployer-aws-lambda/templates/index.js
@@ -93,7 +93,6 @@ const transformBodyToFetch = (body) => {
 }
 
 const excludedHeaders = new Set([
-  'cache-control',
   'content-encoding',
   'content-length',
   'connection',


### PR DESCRIPTION
We remove a bunch of headers that are specific to the HTTP connection that make no sense to set in a FAB and are forbidden by Cloudfront as well, before returning the response to Cloudfront.

But `cache-control` was in that list as well, which means that FABs could not set *any* caching headers running in a lambda. Would be great if you could have a look why that was there @geelen. If there was a good reason to use it somewhere, that case may now stop working.