### PR TITLE
Fix missing code-fence tag

### DIFF
--- a/docs/content/en/kb/configuration.md
+++ b/docs/content/en/kb/configuration.md
@@ -49,6 +49,6 @@ FAB builds use a `fab.config.json5` file:
 
 This file is [JSON5](https://json5.org/), a superset of JSON that's closer to normal JS syntax (i.e. it has comments and unquoted keys). A normal JSON file is valid JSON5, though, if you prefer that, and support for other formats like YAML is [planned](https://github.com/fab-spec/fab/issues/39).
 
-We deviate in one important respect, however, which is that string values of the form `"/regexp/i" are parsed using [regex-parser](https://www.npmjs.com/package/regex-parser). For reference, the exact regexp we use is [here](https://github.com/fab-spec/fab/blob/next/packages/core/src/constants.ts#L8).
+We deviate in one important respect, however, which is that string values of the form `"/regexp/i"` are parsed using [regex-parser](https://www.npmjs.com/package/regex-parser). For reference, the exact regexp we use is [here](https://github.com/fab-spec/fab/blob/next/packages/core/src/constants.ts#L8).
 
 The other special-case value is one like `@ALL_CAPS`, which is used with `dotenv` to look for an appropriate environment variable.


### PR DESCRIPTION
While reading through the docs of FAB, I've noticed there is a code-fence tag missing in order to properly render the docs right here https://fab.dev/kb/configuration#value-types:

![image](https://user-images.githubusercontent.com/439899/102910293-9f0c1480-447a-11eb-9ef0-40b9013876b6.png)

This PR fixes it.