### PR TITLE
When running cli init, recognize yarn workspaces as using yarn

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "cli-ux": "^5.4.5",
     "dotenv": "^8.2.0",
     "execa": "^4.0.0",
+    "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^8.1.0",
     "jju": "^1.4.0",
     "json-keys-sort": "^2.0.0",

--- a/packages/cli/src/Initializer/index.ts
+++ b/packages/cli/src/Initializer/index.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import pkgUp from 'pkg-up'
 import path from 'path'
 import semver from 'semver'
+import findYarnWorkspaceRoot from 'find-yarn-workspace-root'
 
 import { FabInitError, installDependencies, JSON5Config, prompt, useYarn } from '../'
 import {
@@ -78,7 +79,12 @@ export default class Initializer {
 
     /* Then, figure out what kind of project we are */
     const package_json = await this.getPackageJson(package_json_path)
-    const use_yarn = await useYarn(root_dir)
+
+    // if our current directory is managed as a yarn workspace, the yarn.lock file will
+    // be located in the project root instead of the current package directory - so
+    // useYarn should check there to see if this project uses yarn
+    const yarn_root = findYarnWorkspaceRoot(root_dir) || root_dir
+    const use_yarn = await useYarn(yarn_root)
     const additional_dependencies = []
 
     if (empty) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,47 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fab/cli@1.0.0-rc.7":
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@fab/cli/-/cli-1.0.0-rc.7.tgz#adcc481ba38c6eb615172f77b95f7fcc17ac0f50"
+  integrity sha512-9BHl5ahxE1ntZXQKtLO0Nlu5iyrJyGQrTFIXHGK1G4eFvdvMJNNP/gwgfmtP9FG9IeXEgthZWsm2RDQ6TrYA4Q==
+  dependencies:
+    "@fab/core" "1.0.0-rc.7"
+    "@oclif/command" "^1"
+    "@oclif/config" "^1"
+    "@oclif/errors" "^1"
+    "@oclif/plugin-help" "^2"
+    "@types/fs-extra" "^8.0.1"
+    "@types/jju" "^1.4.1"
+    "@types/node" "^10"
+    "@types/prettier" "^1.19.0"
+    "@types/semver" "^6.2.0"
+    chalk "^3.0.0"
+    chokidar "^3.4.0"
+    cli-ux "^5.4.5"
+    dotenv "^8.2.0"
+    execa "^4.0.0"
+    fs-extra "^8.1.0"
+    jju "^1.4.0"
+    json-keys-sort "^2.0.0"
+    pkg-up "^3.1.0"
+    prettier "^1.19.1"
+    pretty-bytes "^5.3.0"
+    regex-parser "^2.2.10"
+    resolve "^1.17.0"
+    semver "^7.1.1"
+    shelljs "^0.8.3"
+    typescript "^3.7.5"
+
+"@fab/core@1.0.0-rc.7":
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@fab/core/-/core-1.0.0-rc.7.tgz#376eec46bf7e34c0284048f65a6c7533c9e599ff"
+  integrity sha512-tfUeUwiT2yqxI2VYzq34ODmrG68eirf+wJ1uYzGhiKEg26l+YDv9VOUv/RIkNqdRHdsqi3NjFDMqxO/jJIV5JA==
+  dependencies:
+    "@types/node" "^12.12.14"
+    mime-types "^2.1.25"
+    path-to-regexp "^6.1.0"
+
 "@fly/v8env@^0.54.0":
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/@fly/v8env/-/v8env-0.54.0.tgz#9e17795f5f2d3df71e3ff9efb970d70778b2dac4"
@@ -4097,6 +4138,13 @@ find-up@^4.0.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
 
 flat@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Our project is a monorepo with our nextjs app living in a yarn workspace. Running the FAB cli didn't recognize this as a yarn-using project, but this change allows it to.