### PR TITLE
Added a preflight check of latest/supported versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^12.12.14",
     "chai": "^4.2.0",
     "chokidar": "^3.3.1",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.0.6",
     "husky": "^3.1.0",
     "lerna": "^3.19.0",
     "lint-staged": "^9.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fab/cli",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.7",
   "description": "The CLI entry-point for the FAB ecosystem",
   "keywords": [
     "fab",
@@ -48,6 +48,7 @@
     "chalk": "^3.0.0",
     "chokidar": "^3.4.0",
     "cli-ux": "^5.4.5",
+    "cross-fetch": "^3.0.6",
     "dotenv": "^8.2.0",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",

--- a/packages/deployer-cf-workers/package.json
+++ b/packages/deployer-cf-workers/package.json
@@ -36,7 +36,7 @@
     "@fab/cli": "1.0.0-rc.8",
     "@fab/core": "1.0.0-rc.8",
     "@types/node": "^12.12.14",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.0.6",
     "file-to-sha512": "^0.0.1",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.0",

--- a/packages/sandbox-node-vm/package.json
+++ b/packages/sandbox-node-vm/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@fab/core": "1.0.0-rc.8",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.0.6",
     "web-streams-polyfill": "^2.1.1"
   },
   "publishConfig": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^12.12.14",
     "@types/yauzl": "^2.9.1",
     "concat-stream": "^2.0.0",
-    "cross-fetch": "^3.0.4",
+    "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
     "file-to-sha512": "^0.0.1",
     "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3045,13 +3045,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
-  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+cross-fetch@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
   dependencies:
-    node-fetch "2.6.0"
-    whatwg-fetch "3.0.0"
+    node-fetch "2.6.1"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -6391,7 +6390,12 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -9174,11 +9178,6 @@ webpack@^4.41.5:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
-
-whatwg-fetch@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Since NextJS pushes point releases all the time, and occasionally things break, adding a preflight check to suggest to user downgrading a point release:

![image](https://user-images.githubusercontent.com/23264/104328149-73150980-54e3-11eb-8a35-e80df55c84e6.png)

Also added a quick note if your local `@fab/cli` is different to than what's on NPM under `latest`, since it was largely the same logic