### PR TITLE
Aliasing 'critters' to an empty object during build

### DIFF
--- a/packages/input-nextjs/src/build.ts
+++ b/packages/input-nextjs/src/build.ts
@@ -107,6 +107,7 @@ export const build: FabBuildStep<InputNextJSArgs, InputNextJSMetadata> = async (
             fs: require.resolve('memfs'),
             path: path.join(shims_dir, 'path-with-posix'),
             '@ampproject/toolbox-optimizer': path.join(shims_dir, 'empty-object'),
+            critters: path.join(shims_dir, 'empty-object'),
             http: path.join(shims_dir, 'http'),
             net: path.join(shims_dir, 'net'),
             https: path.join(shims_dir, 'empty-object'),


### PR DESCRIPTION
This is a package that got added in a recent NextJS point release and breaks the build. Remains to be seen if it's used at all, so first attempt is to alias it to an empty object like the AMP stuff and see if we can get back to green.