### PR TITLE
Add jsx, ts, tsx, and mjs support to @fab/plugin-precompile

### DIFF
--- a/packages/plugin-precompile/src/build.ts
+++ b/packages/plugin-precompile/src/build.ts
@@ -68,6 +68,7 @@ export const build: FabBuildStep<PrecompileArgs, PrecompileMetadata> = async (
           // http: path.join(shims_dir, 'http'),
           // https: path.join(shims_dir, 'empty-object'),
         }),
+        extensions: ['.js', '.jsx', '.ts', '.tsx', '.mjs'],
       },
       module: {
         rules: [


### PR DESCRIPTION
Right now, importing TypeScript files in a plugin and using `@fab/plugin-precompile` results in the infamous:

```txt
Module not found: Error: Can't resolve './path/to/typescript/file` in `/My/plugin/directory`.
```

This lets Webpack discover those TypeScript files and hopefully successfully build, as well as `.jsx`, `.ts`, `.tsx` and `.mjs` files.