### PR TITLE
Updated Request Renderer to pass Body on POST, PUT, or PATCH

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -167,7 +167,7 @@ class Server implements ServerType {
     const fetch_req = new NodeFetchRequest(url, {
       method,
       headers,
-      ...(method === 'POST' ? { body: req.body } : {}),
+      ...((method === 'POST' || method === 'PUT' || method === 'PATCH') ? { body: req.body } : {}),
     })
 
     const production_settings = renderer.metadata?.production_settings


### PR DESCRIPTION
When building the Request in the FAB Server, the Express middleware built the request with a body only for POST requests. This PR updates the `renderReq()` function to also include the body for PUT and PATCH requests.

- The approach taken is a minimal addition of string comparison using logical operators. The performance of this strategy is generally better than building arrays or Regular Expressions to compare against the string.
- An alternative approach could be to simply always pass the body. Although it is generally not used in the other methods, this solution would be syntactically correct. (see: https://tools.ietf.org/html/rfc7231#section-4.3.1)
    
       A payload within a GET request message has no defined semantics;
       sending a payload body on a GET request might cause some existing
       implementations to reject the request.