### PR TITLE
Fix cloudflare cache writes

### DIFF
--- a/packages/deployer-cf-workers/templates/index.js
+++ b/packages/deployer-cf-workers/templates/index.js
@@ -38,7 +38,11 @@ function ReadableStream({ start, cancel }) {
 
 class Cache {
   async set(key, value, ttl_seconds) {
-    KV_FAB_CACHE.put(key, value, ttl_seconds ? { expirationTtl: ttl_seconds } : undefined)
+    return KV_FAB_CACHE.put(
+      key,
+      value,
+      ttl_seconds ? { expirationTtl: ttl_seconds } : undefined
+    )
   }
   async setJSON(key, value, ttl_seconds) {
     await this.set(key, JSON.stringify(value), ttl_seconds)


### PR DESCRIPTION
Discovered that caches write that were working locally with the fab
server were not applying when deployed to cloudflare. Poking around the
web editor I was able to get the writes to take by adding a `return` to
the `Cache.set` function.

I haven't dug in to the testing setup for this project yet but will look into
getting some tests going when I have a bit more time. Wanted to get something
out quick though in case it might save others some time debugging.
