### PR TITLE
Fix env overrides for cloudflare worker deploys

### DIFF
--- a/packages/deployer-cf-workers/src/createPackage.ts
+++ b/packages/deployer-cf-workers/src/createPackage.ts
@@ -32,14 +32,16 @@ export const createPackage: FabPackager<ConfigTypes.CFWorkers> = async (
   const bundle_id = (await pathToSHA512(fab_path)).slice(0, 32)
 
   const fab_server_src = await fs.readFile(path.join(work_dir, 'server.js'), 'utf8')
-  const injections = templateInjections(fab_server_src, assets_url, { bundle_id })
+  const injections = templateInjections(fab_server_src, assets_url, env_overrides, {
+    bundle_id,
+  })
   const template = await fs.readFile(
     path.join(__dirname, '../templates/index.js'),
     'utf8'
   )
 
   const worker_js = `
-    ${injections};
+    ${injections}
     ${template};
   `
   log.tick(`Generated worker file.`)

--- a/packages/deployer-cf-workers/src/templateInjections.ts
+++ b/packages/deployer-cf-workers/src/templateInjections.ts
@@ -1,12 +1,14 @@
-import { FABServerContext } from '@fab/core'
+import { FABServerContext, FabSettings } from '@fab/core'
 
 // language=JavaScript
 export default (
   fab_src: string,
   assets_url: string,
+  env_overrides: FabSettings,
   server_context: FABServerContext
 ) => `
   ${fab_src}; // makes globalThis.__fab
   globalThis.__assets_url = ${JSON.stringify(assets_url)};
-  __server_context = ${JSON.stringify(server_context)}
+  globalThis.__server_context = ${JSON.stringify(server_context)};
+  globalThis.__env_overrides = ${JSON.stringify(env_overrides)};
 `

--- a/packages/deployer-cf-workers/templates/index.js
+++ b/packages/deployer-cf-workers/templates/index.js
@@ -2,6 +2,7 @@ const FAB = globalThis.__fab // injected by UMD
 const ASSETS_URL = globalThis.__assets_url // inlined in packager
 const cache = caches.default
 const server_context = globalThis.__server_context // inlined in packager
+const env_overrides = globalThis.__env_overrides // inlined in packager
 
 const USES_KV_STORE = ASSETS_URL.startsWith('kv://')
 const KV_STORE = globalThis.KV_FAB_ASSETS
@@ -102,10 +103,11 @@ const handleRequest = async (request, within_loop = false) => {
   if (url.pathname.startsWith('/_assets/')) {
     return await assetFetch(url.pathname)
   } else {
-    let settings = FAB.getProdSettings ? FAB.getProdSettings() : {}
-    if (settings.then && typeof settings.then == 'function') {
-      settings = await settings
+    let prodSettings = FAB.getProdSettings ? FAB.getProdSettings() : {}
+    if (prodSettings.then && typeof prodSettings.then == 'function') {
+      prodSettings = await prodSettings
     }
+    const settings = Object.assign({}, prodSettings, env_overrides)
 
     const result = await FAB.render(request, settings)
     if (result instanceof Request) {


### PR DESCRIPTION
When deploying to cloudflare workers with `--env=staging` overrides
specified in the fab config we're not getting bundled into the packaged
worker.
