### PR TITLE
fix(deployer-aws-lambda): waits on lambda state to be Active before assigning to distribution

### DIFF
--- a/packages/deployer-aws-lambda/src/aws.ts
+++ b/packages/deployer-aws-lambda/src/aws.ts
@@ -27,6 +27,18 @@ export const updateLambda = async (
   log(
     `💚✔💚 Updated lambda 💛${response.FunctionName}💛 🖤(version ${response.Version})🖤`
   )
+
+  let state = undefined
+  while (state !== 'Active') {
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+    const functionResponse = await lambda
+      .getFunction({ FunctionName: `${lambda_arn}:${response.Version}` })
+      .promise()
+    log(
+      `Waiting on lambda 💛${response.FunctionName}💛 status to be Active 🖤currently ${state}🖤`
+    )
+    state = functionResponse.Configuration?.State
+  }
   return response.Version
 }
 

--- a/packages/deployer-aws-lambda/src/aws.ts
+++ b/packages/deployer-aws-lambda/src/aws.ts
@@ -39,6 +39,7 @@ export const updateLambda = async (
     )
     state = functionResponse.Configuration?.State
   }
+  log.tick(`Lambda is Active`)
   return response.Version
 }
 


### PR DESCRIPTION
AWS recently released Lambda States, creators like FAB need to wait for a Lambda to be active before they can be used i.e. assigned to a cloud front distribution.

This updates the deploy code to wait for the function to be in an `Active` state before attempting to use it.

https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/
https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html